### PR TITLE
Move back links

### DIFF
--- a/app/views/regions/v1/activate.html
+++ b/app/views/regions/v1/activate.html
@@ -4,12 +4,17 @@
   East of England
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({ 
+    href: "/regions/v1/organisations/" + organisation.code + "/add-email", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-
-      {{ backLink({ href: "/regions/v1/organisations/" + organisation.code + "/add-email", text: "Back" }) }}
-
       <h1 class="govuk-heading-l">Activate {{ organisation.name }}</h1>
 
       <p>When you activate them, they will be able to start recording vaccinations.</p>

--- a/app/views/regions/v1/add-another-email-check.html
+++ b/app/views/regions/v1/add-another-email-check.html
@@ -4,12 +4,17 @@
   East of England
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({ 
+    href: "/regions/v1/organisations/" + organisation.code + "/add-email", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-
-      {{ backLink({ href: "/regions/v1/organisations/" + organisation.code + "/add-email", text: "Back" }) }}
-
       <h1 class="nhsuk-heading-xl">Check and send</h1>
 
       <p>This email will be sent to {{ data["email"] }}:</p>

--- a/app/views/regions/v1/add-another-email.html
+++ b/app/views/regions/v1/add-another-email.html
@@ -4,11 +4,17 @@
   Add another lead user
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/regions/v1/organisations/" + organisation.code, 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-
-      {{ backLink({ href: "/regions/v1/organisations/" + organisation.code, text: "Back" }) }}
 
       <h1 class="nhsuk-heading-l">Add another lead user</h1>
 

--- a/app/views/regions/v1/add-email.html
+++ b/app/views/regions/v1/add-email.html
@@ -4,11 +4,18 @@
   East of England
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/regions/v1/organisation-details", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/regions/v1/organisation-details", text: "Back" }) }}
 
       <h1 class="nhsuk-heading-l">Add a lead user</h1>
 

--- a/app/views/regions/v1/add-organisation.html
+++ b/app/views/regions/v1/add-organisation.html
@@ -4,11 +4,18 @@
   East of England
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({ 
+    href: "/regions/v1", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/regions/v1", text: "Back" }) }}
 
       <h1 class="nhsuk-heading-xl">Find an organisation to invite</h1>
 
@@ -17,7 +24,7 @@
       <div class="nhsuk-form-group">
         <h1 class="nhsuk-label-wrapper">
           <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
-            NHS organisation
+            NHS organisation or community pharmacy
           </label>
         </h1>
         <div class="nhsuk-hint" id="organisationName-hint">

--- a/app/views/regions/v1/check-and-send.html
+++ b/app/views/regions/v1/check-and-send.html
@@ -6,11 +6,18 @@
 
 {% set organisation = {name: organisation.name } %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/regions/v1/add-email",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/regions/v1/add-email", text: "Back" }) }}
 
 
       <h1 class="nhsuk-heading-xl">Check and send</h1>

--- a/app/views/regions/v1/organisation-details.html
+++ b/app/views/regions/v1/organisation-details.html
@@ -4,11 +4,18 @@
   East of England
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/regions/v1/add-organisation",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/regions/v1/add-organisation", text: "Back" }) }}
 
       <h1 class="nhsuk-heading-xl">Check and confirm</h1>
 

--- a/app/views/regions/v1/organisation.html
+++ b/app/views/regions/v1/organisation.html
@@ -4,11 +4,18 @@
   {{ organisation.name }}
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/regions/v1",
+    text: "Back to all organisations",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/regions/v1", text: "Back to all organisations" }) }}
 
       <h1 class="nhsuk-heading-l">{{ organisation.name }}</h1>
 

--- a/app/views/user-admin/v4/_header.html
+++ b/app/views/user-admin/v4/_header.html
@@ -38,7 +38,7 @@
             </a>
           </li>
           <li class="nhsuk-header__navigation-item app-header__navigation-item--right-aligned">
-            <a class="nhsuk-header__navigation-link" href="/user-profile/v4">
+            <a class="nhsuk-header__navigation-link" href="/user-profile/v2">
               jane.smith@nhs.net
             </a>
           </li>
@@ -66,37 +66,4 @@
     </div>
 </header>
 
-
-  <!--{{ header({
-    classes: "nhsuk-header--left",
-    "service": {
-        "name": "Record a vaccination",
-        "href": "/"
-      },
-      "showNav": "true",
-      "showSearch": "false",
-      primaryLinks: [
-        {
-          "url"  : "#",
-          "label" : "Find a patient"
-        },
-        {
-          'url' : '#',
-          'label' : 'Manage vaccines'
-        },
-        {
-          'url' : '#',
-          'label' : 'Manage users'
-        },
-        {
-          'url' : '#',
-          'label' : 'jane.smith@nhs.net'
-        },
-        {
-          'url' : '#',
-          'label' : 'Sign out'
-        }
-      ]
-    })
-  }}-->
 {% endblock %}

--- a/app/views/user-admin/v4/add-user.html
+++ b/app/views/user-admin/v4/add-user.html
@@ -8,12 +8,17 @@
   {% include "user-admin/v4/_header.html" %}
 {% endblock %}
 
+{% block outerContent %}
+  {{ backLink({ 
+    href: "/user-admin/v4", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-
-      {{ backLink({ href: "/user-admin/v4", text: "Back" }) }}
-
       {% if data.showErrors == "true" %}
         {{ errorSummary({
           "titleText": "There is a problem",
@@ -27,7 +32,7 @@
               "href": "#last-name"
             } if (data.lastName == ''),
             {
-              "text": "Enter email address",
+              "text": "Enter NHS email address",
               "href": "#email"
             } if (data.email == ''),
             {
@@ -74,7 +79,7 @@
 
         {{ input({
           "label": {
-            "text": "Email address"
+            "text": "NHS email address"
           },
           "id": "email",
           "name": "email",

--- a/app/views/user-admin/v4/change.html
+++ b/app/views/user-admin/v4/change.html
@@ -9,7 +9,11 @@
 {% endblock %}
 
 {% block outerContent %}
-  {{ backLink({ href: "/user-admin/v4", text: "Back", classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0" }) }}
+  {{ backLink({
+    href: "/user-admin/v4", 
+    text: "Back", 
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/user-admin/v4/check.html
+++ b/app/views/user-admin/v4/check.html
@@ -10,11 +10,18 @@
 
 {% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}
 
+{% block outerContent %}
+  {{ backLink({
+    href: "/user-admin/v4/add-user", 
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {{ backLink({ href: "/user-admin/v4/add-email", text: "Back" }) }}
 
 
       <h1 class="nhsuk-heading-xl">Check and add user</h1>

--- a/app/views/user-profile/v2/_header.html
+++ b/app/views/user-profile/v2/_header.html
@@ -33,7 +33,7 @@
             </a>
           </li>
           <li class="nhsuk-header__navigation-item">
-            <a class="nhsuk-header__navigation-link" href="/user-admin/v2">
+            <a class="nhsuk-header__navigation-link" href="/user-admin/v4">
               Manage users
             </a>
           </li>

--- a/app/views/user-profile/v2/name.html
+++ b/app/views/user-profile/v2/name.html
@@ -12,8 +12,7 @@
   {{ backLink({
     text: "Back",
     href: "/user-profile/v2",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
-
+    classes: "nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
These should all be outside the `<main>` tag, so they can be skipped when using the "skip to main content" link.

Currently this means manually adding some margin above each Back link. This might be fixed upstream in future by https://github.com/nhsuk/nhsuk-frontend/pull/964