### PR TITLE
Reports

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -90,6 +90,12 @@
         <li><a href="/errors/500">Service unavailable</a></li>
       </ul>
 
+      <h2>Vaccines</h2>
+
+      <ul>
+        <li><a href="/vaccines">Vaccines</a></li>
+      </ul>
+
     </div>
   </div>
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -73,6 +73,7 @@
       <ul>
         <li><a href="/reports/v3">Download</a></li>
         <li><a href="/reports/v1">Dates</a></li>
+        <li><a href="/reports/v1-1">Dates + personal details checkbox</a></li>
         <li><a href="/reports/v2">Dates + Vaccines</a></li>
         <li><a href="/reports/v4">Dates + Vaccines + History</a></li>
         <li><a href="/reports/v5">Dates + Vaccines + History + ODS code</a></li>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -68,6 +68,14 @@
       </ul>
 
 
+      <h2>Reports</h2>
+
+      <ul>
+        <li><a href="/reports/v1">Version 1</a></li>
+        <li><a href="/reports/v2">Version 2</a></li>
+        <li><a href="/reports/v3">Version 3</a></li>
+      </ul>
+
       <h2>NHS regions interface</h2>
 
       <ul>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -75,8 +75,8 @@
         <li><a href="/reports/v1">Dates</a></li>
         <li><a href="/reports/v2">Dates + Vaccines</a></li>
         <li><a href="/reports/v4">Dates + Vaccines + History</a></li>
-        <li><a href="/reports/v4">Dates + Vaccines + History + ODS code</a></li>
-        <li><a href="/reports/v4">Dates + Vaccines + History + ODS code + Eligibility</a></li>
+        <li><a href="/reports/v5">Dates + Vaccines + History + ODS code</a></li>
+        <li><a href="/reports/v6">Dates + Vaccines + History + ODS code + Eligibility</a></li>
       </ul>
 
       <h2>NHS regions interface</h2>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -71,10 +71,12 @@
       <h2>Reports</h2>
 
       <ul>
-        <li><a href="/reports/v1">Version 1</a></li>
-        <li><a href="/reports/v2">Version 2</a></li>
-        <li><a href="/reports/v3">Version 3</a></li>
-        <li><a href="/reports/v4">Version 4</a></li>
+        <li><a href="/reports/v3">Download</a></li>
+        <li><a href="/reports/v1">Dates</a></li>
+        <li><a href="/reports/v2">Dates + Vaccines</a></li>
+        <li><a href="/reports/v4">Dates + Vaccines + History</a></li>
+        <li><a href="/reports/v4">Dates + Vaccines + History + ODS code</a></li>
+        <li><a href="/reports/v4">Dates + Vaccines + History + ODS code + Eligibility</a></li>
       </ul>
 
       <h2>NHS regions interface</h2>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -74,6 +74,7 @@
         <li><a href="/reports/v1">Version 1</a></li>
         <li><a href="/reports/v2">Version 2</a></li>
         <li><a href="/reports/v3">Version 3</a></li>
+        <li><a href="/reports/v4">Version 4</a></li>
       </ul>
 
       <h2>NHS regions interface</h2>

--- a/app/views/reports/_header.html
+++ b/app/views/reports/_header.html
@@ -1,0 +1,73 @@
+{% block header %}
+
+<!-- This is HTML instead of a macro for now, as the macro doesn't support classes on primary link items -->
+<header class="nhsuk-header nhsuk-header--left" role="banner">
+
+  <div class="nhsuk-header__container">
+    <div class="nhsuk-header__logo"><a class="nhsuk-header__link nhsuk-header__link--service " href="/" aria-label="NHS homepage">
+
+  <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
+    <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
+    <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+  </svg>
+
+        <span class="nhsuk-header__service-name">
+          Record a vaccination
+        </span>
+      </a>
+    </div>
+
+    </div>
+
+    <div class="nhsuk-navigation-container">
+      <nav class="nhsuk-navigation" id="header-navigation" role="navigation" aria-label="Primary navigation">
+        <ul class="nhsuk-header__navigation-list">
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="#">
+              Find a patient
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="#">
+              Vaccines
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="#">
+              Manage users
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link app-header__navigation-link--current" href="#">
+              Reports
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item app-header__navigation-item--right-aligned">
+            <a class="nhsuk-header__navigation-link" href="/user-profile/v1">
+              jane.smith@nhs.net
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item ">
+            <a class="nhsuk-header__navigation-link href="#">
+              Sign out
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--home">
+            <a class="nhsuk-header__navigation-link" href="/">
+              Home
+            </a>
+          </li>
+          <li class="nhsuk-mobile-menu-container">
+            <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
+              <span class="nhsuk-u-visually-hidden">Browse</span>
+              More
+              <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </button>
+          <ul class="nhsuk-header__drop-down nhsuk-header__drop-down--hidden"></ul></li>
+        </ul>
+      </nav>
+    </div>
+</header>
+{% endblock %}

--- a/app/views/reports/check-1.html
+++ b/app/views/reports/check-1.html
@@ -1,0 +1,127 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  East of England
+{% endblock %}
+
+{% block outerContent %}
+  {{ backLink({
+    href: "/reports/choose-site",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+
+      <h1 class="nhsuk-heading-xl">Check and confirm</h1>
+      {% from "summary-list/macro.njk" import summaryList %}
+
+      {{ summaryList({
+        rows: [
+          {
+            key: {
+              text: "From"
+            },
+            value: {
+              text: "1 Jan 2024"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "To"
+            },
+            value: {
+              text: "2 Feb 2024"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Vaccines"
+            },
+            value: {
+              text: "COVID-19, Flu"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          
+         
+          {
+            key: {
+              text: "Site"
+            },
+            value: {
+              text: "Manchester Royal Infirmary"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "date of birth"
+                }
+              ]
+            }
+          },
+
+
+          {
+            key: {
+              text: "Eligibility"
+            },
+            value: {
+              text: "Example"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "date of birth"
+                }
+              ]
+            }
+          }
+          
+        ]
+      }) }}
+    
+
+      {{ button({
+        "text": "Download file (CSV)",
+        href: "/reports/v6"
+      }) }}
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/reports/check-1.html
+++ b/app/views/reports/check-1.html
@@ -4,6 +4,10 @@
   East of England
 {% endblock %}
 
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
 {% block outerContent %}
   {{ backLink({
     href: "/reports/choose-site",
@@ -73,8 +77,8 @@
               ]
             }
           },
-          
-         
+
+
           {
             key: {
               text: "Site"
@@ -111,10 +115,10 @@
               ]
             }
           }
-          
+
         ]
       }) }}
-    
+
 
       {{ button({
         "text": "Download file (CSV)",

--- a/app/views/reports/check-1.html
+++ b/app/views/reports/check-1.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  East of England
+  Check and confirm
 {% endblock %}
 
 {% block header %}
@@ -10,7 +10,7 @@
 
 {% block outerContent %}
   {{ backLink({
-    href: "/reports/choose-site",
+    href: "/reports/eligibility",
     text: "Back",
     classes: "nhsuk-u-margin-top-4"
   }) }}

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -77,7 +77,7 @@
     
 
       {{ button({
-        "text": "Download",
+        "text": "Download file (CSV)",
         href: "/reports/v5"
       }) }}
 

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -4,6 +4,10 @@
   East of England
 {% endblock %}
 
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
 {% block outerContent %}
   {{ backLink({
     href: "/reports/choose-site",
@@ -73,8 +77,8 @@
               ]
             }
           },
-          
-         
+
+
           {
             key: {
               text: "Site"
@@ -92,10 +96,10 @@
               ]
             }
           }
-          
+
         ]
       }) }}
-    
+
 
       {{ button({
         "text": "Download file (CSV)",

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -1,0 +1,87 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  East of England
+{% endblock %}
+
+{% block outerContent %}
+  {{ backLink({
+    href: "/reports/choose-site",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+
+      <h1 class="nhsuk-heading-xl">Check and confirm</h1>
+      {% from "summary-list/macro.njk" import summaryList %}
+
+      {{ summaryList({
+        rows: [
+          {
+            key: {
+              text: "From"
+            },
+            value: {
+              text: "1 Jan 2024"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "To"
+            },
+            value: {
+              text: "1 Feb 2024"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "date of birth"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Vaccines"
+            },
+            value: {
+              html: "COVID-19, Flu"
+            }
+          }, 
+          {
+            key: {
+              text: "Site"
+            },
+            value: {
+              html: "Manchester Royal Infirmary"
+            }
+          }
+        ]
+      }) }}
+    
+
+      {{ button({
+        "text": "Download",
+        href: "/reports/v5"
+      }) }}
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -44,7 +44,43 @@
               text: "To"
             },
             value: {
-              text: "1 Feb 2024"
+              text: "2 Feb 2024"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Vaccines"
+            },
+            value: {
+              text: "COVID-19, Flu"
+            },
+            actions: {
+              items: [
+                {
+                  href: "#",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          
+         
+          {
+            key: {
+              text: "Site"
+            },
+            value: {
+              text: "Manchester Royal Infirmary"
             },
             actions: {
               items: [
@@ -55,23 +91,8 @@
                 }
               ]
             }
-          },
-          {
-            key: {
-              text: "Vaccines"
-            },
-            value: {
-              html: "COVID-19, Flu"
-            }
-          }, 
-          {
-            key: {
-              text: "Site"
-            },
-            value: {
-              html: "Manchester Royal Infirmary"
-            }
           }
+          
         ]
       }) }}
     

--- a/app/views/reports/choose-dates-1.html
+++ b/app/views/reports/choose-dates-1.html
@@ -1,0 +1,101 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose dates
+{% endblock %}
+
+{% block footer %}
+  {{ footer({
+    links: [
+      {
+        "URL": "/regions/v1/setup-test",
+        "label": "Jump forward in time"
+      }
+    ]
+  })}}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+        {{ backLink({ href: "/reports/v5", text: "Back" }) }}
+
+      <h1 class="nhsuk-heading-xl">Choose dates</h1>
+
+      <p class="nhsuk-body-l">Select the date range for your report.</p>
+
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "From",
+            "classes": "nhsuk-label--l",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "To",
+            "classes": "nhsuk-label--l",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+
+
+      {{ button({
+        "text": "Continue",
+        "href": "/reports/choose-vaccines-1"
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/reports/choose-dates-1.html
+++ b/app/views/reports/choose-dates-1.html
@@ -4,15 +4,8 @@
   Choose dates
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
+{% block header %}
+  {% include "reports/_header.html" %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -19,6 +19,8 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
+        {{ backLink({ href: "/reports/v5", text: "Back" }) }}
+
       <h1 class="nhsuk-heading-xl">Choose dates</h1>
 
       <p class="nhsuk-body-l">Select the date range for your report.</p>
@@ -89,8 +91,8 @@
 
 
       {{ button({
-        "text": "Download",
-        "href": "/regions/v1/add-organisation"
+        "text": "Continue",
+        "href": "/reports/choose-vaccines"
       }) }}
 
     </div>

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -4,15 +4,8 @@
   Choose dates
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
+{% block header %}
+  {% include "reports/_header.html" %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -1,0 +1,99 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose dates
+{% endblock %}
+
+{% block footer %}
+  {{ footer({
+    links: [
+      {
+        "URL": "/regions/v1/setup-test",
+        "label": "Jump forward in time"
+      }
+    ]
+  })}}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-xl">Choose dates</h1>
+
+      <p class="nhsuk-body-l">Select the date range for your report.</p>
+
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "From",
+            "classes": "nhsuk-label--l",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "To",
+            "classes": "nhsuk-label--l",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+
+
+      {{ button({
+        "text": "Download",
+        "href": "/regions/v1/add-organisation"
+      }) }}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/reports/choose-site-1.html
+++ b/app/views/reports/choose-site-1.html
@@ -1,0 +1,67 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose site
+{% endblock %}
+
+
+{% block header %}
+  {% include "vaccines/_header.html" %}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+
+{{ backLink({ href: "/reports/choose-vaccines", text: "Back" }) }}
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+    
+          <h1 class="nhsuk-heading-xl">Choose site</h1>
+    
+          <form action="/regions/v1/organisation-details" method="post">
+    
+          <div class="nhsuk-form-group">
+            <h1 class="nhsuk-label-wrapper">
+              <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
+            Select a site for your report
+              </label>
+            </h1>
+            <div class="nhsuk-hint" id="organisationName-hint">
+              Search by name or ODS code
+            </div>
+            <select class="nhsuk-select" id="organisationCode" name="organisationCode"
+              data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
+              <option selected value=""></option>
+    
+              {% for code, name in data.nhsTrusts %}
+                <option value="{{ code }}">{{ name }} ({{code }})</option>
+              {% endfor %}
+              {% for code, data in data.nhsPharmacies %}
+                <option value="{{ code }}">{{ data.name }}, {{ data.address }}, {{ data.postcode | upper }} ({{code }})</option>
+              {% endfor %}
+            </select>
+          </div>
+    
+          {{ button({
+            "text": "Continue",
+            "href": "/reports/eligibility"
+          }) }}
+
+        </form>
+    
+    
+        </div>
+      </div>
+
+
+
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/views/reports/choose-site-1.html
+++ b/app/views/reports/choose-site-1.html
@@ -16,31 +16,41 @@
         <div class="nhsuk-grid-column-two-thirds">
 
 
-          <h1 class="nhsuk-heading-xl">Choose site</h1>
+          <h1 class="nhsuk-heading-xl">Choose sites</h1>
 
           <form action="/regions/v1/organisation-details" method="post">
 
-          <div class="nhsuk-form-group">
-            <h1 class="nhsuk-label-wrapper">
-              <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
-            Select a site for your report
-              </label>
-            </h1>
-            <div class="nhsuk-hint" id="organisationName-hint">
-              Search by name or ODS code
-            </div>
-            <select class="nhsuk-select" id="organisationCode" name="organisationCode"
-              data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
-              <option selected value=""></option>
+            {{ checkboxes({
+                "idPrefix": "example",
+                "name": "example",
+                "fieldset": {
+                  "legend": {
+                    "text": "",
+                    "classes": "nhsuk-fieldset__legend--m",
+                    isPageHeading: true
+                  }
+                },
 
-              {% for code, name in data.nhsTrusts %}
-                <option value="{{ code }}">{{ name }} ({{code }})</option>
-              {% endfor %}
-              {% for code, data in data.nhsPharmacies %}
-                <option value="{{ code }}">{{ data.name }}, {{ data.address }}, {{ data.postcode | upper }} ({{code }})</option>
-              {% endfor %}
-            </select>
-          </div>
+                "items": [
+                  {
+                    "value": "covid-19",
+                    "text": "Verington (RH63S)"
+                  },
+                  {
+                    "value": "Flu",
+                    "text": "Tower (S204X)"
+                  },
+                  {
+                    "value": "Pertussis",
+                    "text": "The Exchange (RH5S9)"
+                  },
+                  {
+                    "value": "RSV",
+                    "text": "Willowbank Day Hospital (RH5C4)"
+                  }
+                  ]
+              }) }}
+
 
           {{ button({
             "text": "Continue",

--- a/app/views/reports/choose-site-1.html
+++ b/app/views/reports/choose-site-1.html
@@ -4,14 +4,9 @@
   Choose site
 {% endblock %}
 
-
 {% block header %}
-  {% include "vaccines/_header.html" %}
+  {% include "reports/_header.html" %}
 {% endblock %}
-
-
-
-
 
 {% block content %}
 
@@ -19,12 +14,12 @@
 
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-    
-    
+
+
           <h1 class="nhsuk-heading-xl">Choose site</h1>
-    
+
           <form action="/regions/v1/organisation-details" method="post">
-    
+
           <div class="nhsuk-form-group">
             <h1 class="nhsuk-label-wrapper">
               <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
@@ -37,7 +32,7 @@
             <select class="nhsuk-select" id="organisationCode" name="organisationCode"
               data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
               <option selected value=""></option>
-    
+
               {% for code, name in data.nhsTrusts %}
                 <option value="{{ code }}">{{ name }} ({{code }})</option>
               {% endfor %}
@@ -46,15 +41,15 @@
               {% endfor %}
             </select>
           </div>
-    
+
           {{ button({
             "text": "Continue",
             "href": "/reports/eligibility"
           }) }}
 
         </form>
-    
-    
+
+
         </div>
       </div>
 

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -1,0 +1,67 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose site
+{% endblock %}
+
+
+{% block header %}
+  {% include "vaccines/_header.html" %}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+
+{{ backLink({ href: "/reports/choose-vaccines", text: "Back" }) }}
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+    
+          <h1 class="nhsuk-heading-xl">Choose site</h1>
+    
+          <form action="/regions/v1/organisation-details" method="post">
+    
+          <div class="nhsuk-form-group">
+            <h1 class="nhsuk-label-wrapper">
+              <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
+            Select a site for your report
+              </label>
+            </h1>
+            <div class="nhsuk-hint" id="organisationName-hint">
+              Search by name or ODS code
+            </div>
+            <select class="nhsuk-select" id="organisationCode" name="organisationCode"
+              data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
+              <option selected value=""></option>
+    
+              {% for code, name in data.nhsTrusts %}
+                <option value="{{ code }}">{{ name }} ({{code }})</option>
+              {% endfor %}
+              {% for code, data in data.nhsPharmacies %}
+                <option value="{{ code }}">{{ data.name }}, {{ data.address }}, {{ data.postcode | upper }} ({{code }})</option>
+              {% endfor %}
+            </select>
+          </div>
+    
+          {{ button({
+            "text": "Continue",
+            "href": "/reports/check"
+          }) }}
+
+        </form>
+    
+    
+        </div>
+      </div>
+
+
+
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -4,14 +4,9 @@
   Choose site
 {% endblock %}
 
-
 {% block header %}
-  {% include "vaccines/_header.html" %}
+  {% include "reports/_header.html" %}
 {% endblock %}
-
-
-
-
 
 {% block content %}
 
@@ -19,12 +14,12 @@
 
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-    
-    
+
+
           <h1 class="nhsuk-heading-xl">Choose site</h1>
-    
+
           <form action="/regions/v1/organisation-details" method="post">
-    
+
           <div class="nhsuk-form-group">
             <h1 class="nhsuk-label-wrapper">
               <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
@@ -37,7 +32,7 @@
             <select class="nhsuk-select" id="organisationCode" name="organisationCode"
               data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
               <option selected value=""></option>
-    
+
               {% for code, name in data.nhsTrusts %}
                 <option value="{{ code }}">{{ name }} ({{code }})</option>
               {% endfor %}
@@ -46,15 +41,15 @@
               {% endfor %}
             </select>
           </div>
-    
+
           {{ button({
             "text": "Continue",
             "href": "/reports/check"
           }) }}
 
         </form>
-    
-    
+
+
         </div>
       </div>
 

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -16,31 +16,41 @@
         <div class="nhsuk-grid-column-two-thirds">
 
 
-          <h1 class="nhsuk-heading-xl">Choose site</h1>
+          <h1 class="nhsuk-heading-xl">Locations</h1>
 
           <form action="/regions/v1/organisation-details" method="post">
 
-          <div class="nhsuk-form-group">
-            <h1 class="nhsuk-label-wrapper">
-              <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
-            Select a site for your report
-              </label>
-            </h1>
-            <div class="nhsuk-hint" id="organisationName-hint">
-              Search by name or ODS code
-            </div>
-            <select class="nhsuk-select" id="organisationCode" name="organisationCode"
-              data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
-              <option selected value=""></option>
+            {{ checkboxes({
+                "idPrefix": "example",
+                "name": "example",
+                "fieldset": {
+                  "legend": {
+                    "text": "",
+                    "classes": "nhsuk-fieldset__legend--m",
+                    isPageHeading: true
+                  }
+                },
 
-              {% for code, name in data.nhsTrusts %}
-                <option value="{{ code }}">{{ name }} ({{code }})</option>
-              {% endfor %}
-              {% for code, data in data.nhsPharmacies %}
-                <option value="{{ code }}">{{ data.name }}, {{ data.address }}, {{ data.postcode | upper }} ({{code }})</option>
-              {% endfor %}
-            </select>
-          </div>
+                "items": [
+                  {
+                    "value": "covid-19",
+                    "text": "Verington (RH63S)"
+                  },
+                  {
+                    "value": "Flu",
+                    "text": "Tower (S204X)"
+                  },
+                  {
+                    "value": "Pertussis",
+                    "text": "The Exchange (RH5S9)"
+                  },
+                  {
+                    "value": "RSV",
+                    "text": "Willowbank Day Hospital (RH5C4)"
+                  }
+                  ]
+              }) }}
+
 
           {{ button({
             "text": "Continue",

--- a/app/views/reports/choose-vaccines-1.html
+++ b/app/views/reports/choose-vaccines-1.html
@@ -55,7 +55,7 @@
             </form>
             {{ button({
               "text": "Continue",
-              "href": "/reports/choose-site"
+              "href": "/reports/choose-site-1"
             }) }}
           </form>
     

--- a/app/views/reports/choose-vaccines-1.html
+++ b/app/views/reports/choose-vaccines-1.html
@@ -8,19 +8,17 @@
   {% include "reports/_header.html" %}
 {% endblock %}
 
-
-
 {% block content %}
-   
+
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-    
+
           {{ backLink({ href: "/reports/choose-dates", text: "Back" }) }}
-    
+
           <h1 class="nhsuks-heading-xl">Choose vaccine</h1>
           <p class="nhsuk-body-l">Add and edit your vaccines.</p>
-  
-        
+
+
             <form>
               {{ checkboxes({
                 "idPrefix": "example",
@@ -32,7 +30,7 @@
                     isPageHeading: true
                   }
                 },
-              
+
                 "items": [
                   {
                     "value": "covid-19",
@@ -58,11 +56,11 @@
               "href": "/reports/choose-site-1"
             }) }}
           </form>
-    
-    
+
+
         </div>
       </div>
-    
+
 
 
 

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -1,0 +1,69 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose vaccine
+{% endblock %}
+
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
+
+
+{% block content %}
+   
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+          {{ backLink({ href: "/reports/v4", text: "Back" }) }}
+    
+          <h1 class="nhsuks-heading-xl">Choose vaccine</h1>
+          <p class="nhsuk-body-l">Add and edit your vaccines.</p>
+    
+          <form action="/user-admin/v1/check" method="post" novalidate="true">
+    
+        
+            <div class="nhsuk-form-group">
+
+                <fieldset class="nhsuk-fieldset">
+                  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                  </legend>
+              
+                  <div class="nhsuk-radios">
+              
+                    <div class="nhsuk-radios__item">
+                      <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+                      <label class="nhsuk-label nhsuk-radios__label" for="example-1">
+                        COVID-19
+                      </label>
+                    </div>
+              
+                    <div class="nhsuk-radios__item">
+                      <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no">
+                      <label class="nhsuk-label nhsuk-radios__label" for="example-2">
+                        Flu
+                      </label>
+                    </div>
+              
+                  </div>
+                </fieldset>
+              
+              </div>
+    
+    
+            {{ button({
+              "text": "Continue"
+          }) }}
+          </form>
+    
+    
+        </div>
+      </div>
+    
+
+
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -15,45 +15,48 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
     
-          {{ backLink({ href: "/reports/v4", text: "Back" }) }}
+          {{ backLink({ href: "/reports/choose-dates", text: "Back" }) }}
     
           <h1 class="nhsuks-heading-xl">Choose vaccine</h1>
           <p class="nhsuk-body-l">Add and edit your vaccines.</p>
-    
-          <form action="/user-admin/v1/check" method="post" novalidate="true">
-    
+  
         
-            <div class="nhsuk-form-group">
-
-                <fieldset class="nhsuk-fieldset">
-                  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-                  </legend>
+            <form>
+              {{ checkboxes({
+                "idPrefix": "example",
+                "name": "example",
+                "fieldset": {
+                  "legend": {
+                    "text": "Vaccines",
+                    "classes": "nhsuk-fieldset__legend--m",
+                    isPageHeading: true
+                  }
+                },
               
-                  <div class="nhsuk-radios">
-              
-                    <div class="nhsuk-radios__item">
-                      <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
-                      <label class="nhsuk-label nhsuk-radios__label" for="example-1">
-                        COVID-19
-                      </label>
-                    </div>
-              
-                    <div class="nhsuk-radios__item">
-                      <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no">
-                      <label class="nhsuk-label nhsuk-radios__label" for="example-2">
-                        Flu
-                      </label>
-                    </div>
-              
-                  </div>
-                </fieldset>
-              
-              </div>
-    
-    
+                "items": [
+                  {
+                    "value": "covid-19",
+                    "text": "COVID-19"
+                  },
+                  {
+                    "value": "Flu",
+                    "text": "Flu"
+                  },
+                  {
+                    "value": "Pertussis",
+                    "text": "Pertussis"
+                  },
+                  {
+                    "value": "RSV",
+                    "text": "RSV"
+                  }
+                  ]
+              }) }}
+            </form>
             {{ button({
-              "text": "Continue"
-          }) }}
+              "text": "Continue",
+              "href": "/reports/choose-site"
+            }) }}
           </form>
     
     

--- a/app/views/reports/eligibility.html
+++ b/app/views/reports/eligibility.html
@@ -11,44 +11,73 @@
 
 
 {% block content %}
-   
+
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
-    
+
           {{ backLink({ href: "/reports/choose-dates", text: "Back" }) }}
-    
-          <h1 class="nhsuks-heading-xl">Select eligibility</h1>
-          <p class="nhsuk-body-l">Select eligibility criteria.</p>
-  
-        
-            <form>
+
+
+            <form class="nhsuk-u-margin-top-8">
               {{ checkboxes({
                 "idPrefix": "example",
                 "name": "example",
                 "fieldset": {
                   "legend": {
-                    "text": "",
-                    "classes": "nhsuk-fieldset__legend--m",
+                    "text": "Eligibility",
+                    "classes": "nhsuk-fieldset__legend--xl",
                     isPageHeading: true
                   }
                 },
-              
+
                 "items": [
                   {
                     "value": "covid-19",
-                    "text": "Example"
+                    "text": "Residents in care home"
                   },
                   {
                     "value": "Flu",
-                    "text": "Example"
+                    "text": "Staff working in care homes"
                   },
                   {
                     "value": "Pertussis",
-                    "text": "Example"
+                    "text": "Healthcare workers"
                   },
                   {
                     "value": "RSV",
-                    "text": "Example"
+                    "text": "Social care workers"
+                  },
+                  {
+                    "value": "covid-19",
+                    "text": "Age-based eligibility"
+                  },
+                  {
+                    "value": "Flu",
+                    "text": "Pregnancy"
+                  },
+                  {
+                    "value": "Pertussis",
+                    "text": "People with immunosuppression"
+                  },
+                  {
+                    "value": "RSV",
+                    "text": "People in other clinical risk groups"
+                  },
+                  {
+                    "value": "RSV",
+                    "text": "People who are homeless or live in closed settings like supported living accommodation"
+                  },
+                  {
+                    "value": "covid-19",
+                    "text": "Household contacts of people with immunosuppression"
+                  },
+                  {
+                    "value": "Flu",
+                    "text": "Carer"
+                  },
+                  {
+                    "value": "Pertussis",
+                    "text": "People that have had CAR-T therapy or stem cell transplantation since receiving their last"
                   }
                   ]
               }) }}
@@ -58,11 +87,11 @@
               "href": "/reports/check-1"
             }) }}
           </form>
-    
-    
+
+
         </div>
       </div>
-    
+
 
 
 

--- a/app/views/reports/eligibility.html
+++ b/app/views/reports/eligibility.html
@@ -17,8 +17,8 @@
     
           {{ backLink({ href: "/reports/choose-dates", text: "Back" }) }}
     
-          <h1 class="nhsuks-heading-xl">Choose vaccine</h1>
-          <p class="nhsuk-body-l">Add and edit your vaccines.</p>
+          <h1 class="nhsuks-heading-xl">Select eligibility</h1>
+          <p class="nhsuk-body-l">Select eligibility criteria.</p>
   
         
             <form>
@@ -36,26 +36,26 @@
                 "items": [
                   {
                     "value": "covid-19",
-                    "text": "COVID-19"
+                    "text": "Example"
                   },
                   {
                     "value": "Flu",
-                    "text": "Flu"
+                    "text": "Example"
                   },
                   {
                     "value": "Pertussis",
-                    "text": "Pertussis"
+                    "text": "Example"
                   },
                   {
                     "value": "RSV",
-                    "text": "RSV"
+                    "text": "Example"
                   }
                   ]
               }) }}
             </form>
             {{ button({
               "text": "Continue",
-              "href": "/reports/choose-site"
+              "href": "/reports/check-1"
             }) }}
           </form>
     

--- a/app/views/reports/v1-1.html
+++ b/app/views/reports/v1-1.html
@@ -1,0 +1,95 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Page title
+{% endblock %}
+
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Reports</h1>
+
+      <p>Download a spreadsheet of the vaccinations you have recorded.</p>
+
+      {% from 'warning-callout/macro.njk' import warningCallout %}
+
+      <h2 class="nhsuk-heading-m">Create report</h2>
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "From",
+            "classes": "nhsuk-label--s"
+          }
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "To",
+            "classes": "nhsuk-label--s"
+          }
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+      {{ checkboxes({
+        classes: "nhsuk-u-margin-top-8",
+        items: [
+          {
+            value: "personal-data",
+            text: "Include personal details of patient",
+            hint: {
+              text: "Name, NHS number, data of birth, gender, address"
+            }
+          }
+        ]
+
+      })}}
+
+      <div class="nhsuk-u-margin-top-8">
+        {{ button({
+          "text": "Download file (CSV)"
+        }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/reports/v1.html
+++ b/app/views/reports/v1.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Page title
+{% endblock %}
+
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Page title</h1>
+
+      </div>
+    </div>
+{% endblock %}

--- a/app/views/reports/v2.html
+++ b/app/views/reports/v2.html
@@ -115,7 +115,7 @@
       </form>
 
       {{ button({
-        "text": "Download",
+        "text": "Download file (CSV)",
         "href": "#"
       }) }}
 

--- a/app/views/reports/v2.html
+++ b/app/views/reports/v2.html
@@ -31,7 +31,7 @@
         "fieldset": {
           "legend": {
             "text": "From",
-            "classes": "nhsuk-label--l",
+            "classes": "nhsuk-label--m",
             "isPageHeading": true
           }
         },
@@ -63,7 +63,7 @@
         "fieldset": {
           "legend": {
             "text": "To",
-            "classes": "nhsuk-label--l",
+            "classes": "nhsuk-label--m",
             "isPageHeading": true
           }
         },
@@ -86,7 +86,40 @@
         ]
       }) }}
 
+      {% from 'checkboxes/macro.njk' import checkboxes %}
 
+      <form>
+        {{ checkboxes({
+          "idPrefix": "example",
+          "name": "example",
+          "fieldset": {
+            "legend": {
+              "text": "Vaccines",
+              "classes": "nhsuk-fieldset__legend--m",
+              isPageHeading: true
+            }
+          },
+        
+          "items": [
+            {
+              "value": "covid-19",
+              "text": "COVID-19"
+            },
+            {
+              "value": "Flu",
+              "text": "Flu"
+            },
+            {
+              "value": "Pertussis",
+              "text": "Pertussis"
+            },
+            {
+              "value": "RSV",
+              "text": "RSV"
+            }
+            ]
+        }) }}
+      </form>
 
       {{ button({
         "text": "Download",
@@ -96,49 +129,8 @@
     </div>
   </div>
 
-  {% if (data.organisationsAdded | length) > 0 %}
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
 
-          <table class="nhsuk-table">
-            <caption class="nhsuk-table__caption">Organisations added</caption>
-            <thead role="rowgroup" class="nhsuk-table__head">
-              <tr role="row">
-                <th role="columnheader" class="" scope="col">
-                  Organisation
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  ODS code
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  Type
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody class="nhsuk-table__body">
-              {% for organisation in data.organisationsAdded %}
-                <tr role="row" class="nhsuk-table__row">
-                  <td class="nhsuk-table__cell">
-                    <a href="/regions/v1/organisations/{{ organisation.code }}">{{ organisation.name }}</a>
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.code }}
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.type }}
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.status }}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-      </div>
-    </div>
-  {% endif %}
+
+
 
 {% endblock %}

--- a/app/views/reports/v2.html
+++ b/app/views/reports/v2.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Page title
+{% endblock %}
+
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Page title</h1>
+
+      </div>
+    </div>
+{% endblock %}

--- a/app/views/reports/v2.html
+++ b/app/views/reports/v2.html
@@ -14,9 +14,21 @@
 
       <h1 class="nhsuk-heading-xl">Reports</h1>
 
-      <p class="nhsuk-body-l">Create and run reports from your organisation.</p>
+    
 
       {% from 'date-input/macro.njk' import dateInput %}
+
+      
+      <p>Download a spreadsheet of the vaccinations you have recorded.</p>
+
+      {% from 'warning-callout/macro.njk' import warningCallout %}
+
+      {{ warningCallout({
+        "heading": "Important",
+        "HTML": "<p>These files will contain the personal details of patients and so should be stored securely or processed to anonymise them.</p>"
+      }) }}
+
+      <h2 class="nhsuk-heading-m">Select date range</h2>
 
       {{ dateInput({
         "id": "example",
@@ -24,12 +36,8 @@
         "fieldset": {
           "legend": {
             "text": "From",
-            "classes": "nhsuk-label--m",
-            "isPageHeading": true
+            "classes": "nhsuk-label--s"
           }
-        },
-        "hint": {
-          "text": "For example, 15 3 1984"
         },
         "items": [
           {
@@ -47,21 +55,14 @@
         ]
       }) }}
 
-
-      {% from 'date-input/macro.njk' import dateInput %}
-
       {{ dateInput({
         "id": "example",
         "namePrefix": "example",
         "fieldset": {
           "legend": {
             "text": "To",
-            "classes": "nhsuk-label--m",
-            "isPageHeading": true
+            "classes": "nhsuk-label--s"
           }
-        },
-        "hint": {
-          "text": "For example, 15 3 1984"
         },
         "items": [
           {
@@ -87,7 +88,7 @@
           "name": "example",
           "fieldset": {
             "legend": {
-              "text": "Vaccines",
+              "text": "Select vaccines",
               "classes": "nhsuk-fieldset__legend--m",
               isPageHeading: true
             }

--- a/app/views/reports/v3.html
+++ b/app/views/reports/v3.html
@@ -12,8 +12,16 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Page title</h1>
+      <h1 class="nhsuk-heading-l">Reports</h1>
 
+      <p>Download a spreadsheet of all the vaccinations you have ever recorded.</p>
+
+      <div class="nhsuk-u-margin-top-8">
+        {{ button({
+          "text": "Download file (CSV)"
+        }) }}
       </div>
+
     </div>
+  </div>
 {% endblock %}

--- a/app/views/reports/v3.html
+++ b/app/views/reports/v3.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Page title
+{% endblock %}
+
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Page title</h1>
+
+      </div>
+    </div>
+{% endblock %}

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -1,5 +1,9 @@
 {% extends 'layout.html' %}
 
+{% block header %}
+  {% include "reports/_header.html" %}
+{% endblock %}
+
 {% block pageTitle %}
   Reports
 {% endblock %}

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -12,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports (v4)</h1>
+      <h1 class="nhsuk-heading-xl">Reports</h1>
 
       <p class="nhsuk-body-l">Create and run reports from your organisation.</p>
 

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -23,74 +23,11 @@
 
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 
-      {% from 'date-input/macro.njk' import dateInput %}
-
-      {{ dateInput({
-        "id": "example",
-        "namePrefix": "example",
-        "fieldset": {
-          "legend": {
-            "text": "From",
-            "classes": "nhsuk-label--l",
-            "isPageHeading": true
-          }
-        },
-        "hint": {
-          "text": "For example, 15 3 1984"
-        },
-        "items": [
-          {
-            "name": "day",
-            "classes": "nhsuk-input--width-2"
-          },
-          {
-            "name": "month",
-            "classes": "nhsuk-input--width-2"
-          },
-          {
-            "name": "year",
-            "classes": "nhsuk-input--width-4"
-          }
-        ]
-      }) }}
-
-
-      {% from 'date-input/macro.njk' import dateInput %}
-
-      {{ dateInput({
-        "id": "example",
-        "namePrefix": "example",
-        "fieldset": {
-          "legend": {
-            "text": "To",
-            "classes": "nhsuk-label--l",
-            "isPageHeading": true
-          }
-        },
-        "hint": {
-          "text": "For example, 15 3 1984"
-        },
-        "items": [
-          {
-            "name": "day",
-            "classes": "nhsuk-input--width-2"
-          },
-          {
-            "name": "month",
-            "classes": "nhsuk-input--width-2"
-          },
-          {
-            "name": "year",
-            "classes": "nhsuk-input--width-4"
-          }
-        ]
-      }) }}
-
-
+    
 
       {{ button({
-        "text": "Download",
-        "href": "/regions/v1/add-organisation"
+        "text": "Create report",
+        "href": "/reports/choose-vaccines"
       }) }}
 
     </div>

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -23,8 +23,8 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Reports</h1>
-
+      <h1 class="nhsuk-heading-xl">Reports</h1> 
+      
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 
     
@@ -42,20 +42,17 @@
       <div class="nhsuk-grid-column-full">
 
           <table class="nhsuk-table">
-            <caption class="nhsuk-table__caption">Organisations added</caption>
+            <caption class="nhsuk-table__caption">Reports added</caption>
             <thead role="rowgroup" class="nhsuk-table__head">
               <tr role="row">
                 <th role="columnheader" class="" scope="col">
-                  Organisation
+                  Name
                 </th>
                 <th role="columnheader" class="" scope="col">
-                  ODS code
+                  Date
                 </th>
                 <th role="columnheader" class="" scope="col">
-                  Type
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  Status
+                  Vaccine
                 </th>
               </tr>
             </thead>

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -12,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports</h1>
+      <h1 class="nhsuk-heading-xl">Reports (v4)</h1>
 
       <p class="nhsuk-body-l">Create and run reports from your organisation.</p>
 
@@ -115,7 +115,7 @@
       </form>
 
       {{ button({
-        "text": "Download",
+        "text": "Download file (CSV)",
         "href": "/regions/v1/add-organisation"
       }) }}
 

--- a/app/views/reports/v4.html
+++ b/app/views/reports/v4.html
@@ -1,9 +1,5 @@
 {% extends 'layout.html' %}
 
-{% block header %}
-  {% include "reports/_header.html" %}
-{% endblock %}
-
 {% block pageTitle %}
   Reports
 {% endblock %}
@@ -21,62 +17,189 @@
 
 {% block content %}
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
+    <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports</h1> 
-      
+      <h1 class="nhsuk-heading-xl">Reports</h1>
+
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 
-    
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "From",
+            "classes": "nhsuk-label--m",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+
+      {% from 'date-input/macro.njk' import dateInput %}
+
+      {{ dateInput({
+        "id": "example",
+        "namePrefix": "example",
+        "fieldset": {
+          "legend": {
+            "text": "To",
+            "classes": "nhsuk-label--m",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "text": "For example, 15 3 1984"
+        },
+        "items": [
+          {
+            "name": "day",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "month",
+            "classes": "nhsuk-input--width-2"
+          },
+          {
+            "name": "year",
+            "classes": "nhsuk-input--width-4"
+          }
+        ]
+      }) }}
+
+      {% from 'checkboxes/macro.njk' import checkboxes %}
+
+      <form>
+        {{ checkboxes({
+          "idPrefix": "example",
+          "name": "example",
+          "fieldset": {
+            "legend": {
+              "text": "Vaccines",
+              "classes": "nhsuk-fieldset__legend--m",
+              isPageHeading: true
+            }
+          },
+        
+          "items": [
+            {
+              "value": "covid-19",
+              "text": "COVID-19"
+            },
+            {
+              "value": "Flu",
+              "text": "Flu"
+            },
+            {
+              "value": "Pertussis",
+              "text": "Pertussis"
+            },
+            {
+              "value": "RSV",
+              "text": "RSV"
+            }
+            ]
+        }) }}
+      </form>
 
       {{ button({
-        "text": "Create report",
-        "href": "/reports/choose-vaccines"
+        "text": "Download",
+        "href": "/regions/v1/add-organisation"
       }) }}
+
+      {% from 'tables/macro.njk' import table %}
+
+      {{ table({
+        panel: false,
+        caption: "Previous reports",
+        firstCellIsHeader: false,
+        head: [
+          {
+            text: "From"
+          },
+          {
+            text: "To"
+          },
+          {
+            text: "Vaccines"
+          },
+          {
+          text: ""
+        }
+
+        ],
+        rows: [
+          [
+            {
+              text: "1 Jan 2024"
+            },
+            {
+              text: "1 Feb 2024"
+            },
+            {
+              text:"COVID-19"
+            },
+            {
+              html:"<a href='#'> Download (200 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "4 Apr 2024"
+            },
+            {
+              text: "4 May 2024"
+            },
+            {
+              text:"COVID-19, Flu"
+            },
+            {
+              html:"<a href='#'> Download (600 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "16 Jun 2024"
+            },
+            {
+              text: "21 Jul 2024"
+            },
+            {
+              text:"COVID-19, Flu, Pertussis, RSV"
+            },
+            {
+              html:"<a href='#'> Download (1.2 mbs)</a>"
+            }
+            ]
+        
+        ]
+      }) }}
+
 
     </div>
   </div>
 
-  {% if (data.organisationsAdded | length) > 0 %}
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-full">
 
-          <table class="nhsuk-table">
-            <caption class="nhsuk-table__caption">Reports added</caption>
-            <thead role="rowgroup" class="nhsuk-table__head">
-              <tr role="row">
-                <th role="columnheader" class="" scope="col">
-                  Name
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  Date
-                </th>
-                <th role="columnheader" class="" scope="col">
-                  Vaccine
-                </th>
-              </tr>
-            </thead>
-            <tbody class="nhsuk-table__body">
-              {% for organisation in data.organisationsAdded %}
-                <tr role="row" class="nhsuk-table__row">
-                  <td class="nhsuk-table__cell">
-                    <a href="/regions/v1/organisations/{{ organisation.code }}">{{ organisation.name }}</a>
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.code }}
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.type }}
-                  </td>
-                  <td class="nhsuk-table__cell ">
-                    {{ organisation.status }}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-      </div>
-    </div>
-  {% endif %}
+
+
 
 {% endblock %}

--- a/app/views/reports/v5.html
+++ b/app/views/reports/v5.html
@@ -19,7 +19,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports</h1>
+      <h1 class="nhsuk-heading-xl">Reports (v5)</h1>
 
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 

--- a/app/views/reports/v5.html
+++ b/app/views/reports/v5.html
@@ -19,7 +19,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports (v5)</h1>
+      <h1 class="nhsuk-heading-xl">Reports</h1>
 
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 

--- a/app/views/reports/v5.html
+++ b/app/views/reports/v5.html
@@ -1,0 +1,107 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Reports
+{% endblock %}
+
+{% block footer %}
+  {{ footer({
+    links: [
+      {
+        "URL": "/regions/v1/setup-test",
+        "label": "Jump forward in time"
+      }
+    ]
+  })}}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <h1 class="nhsuk-heading-xl">Reports</h1>
+
+      <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
+
+      {{ button({
+        "text": "Create report",
+        "href": "/reports/choose-dates"
+      }) }}
+
+      {% from 'tables/macro.njk' import table %}
+
+      {{ table({
+        panel: false,
+        caption: "Previous reports",
+        firstCellIsHeader: false,
+        head: [
+          {
+            text: "From"
+          },
+          {
+            text: "To"
+          },
+          {
+            text: "Vaccines"
+          },
+          {
+          text: ""
+        }
+
+        ],
+        rows: [
+          [
+            {
+              text: "1 Jan 2024"
+            },
+            {
+              text: "1 Feb 2024"
+            },
+            {
+              text:"COVID-19"
+            },
+            {
+              html:"<a href='#'> Download (200 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "4 Apr 2024"
+            },
+            {
+              text: "4 May 2024"
+            },
+            {
+              text:"COVID-19, Flu"
+            },
+            {
+              html:"<a href='#'> Download (600 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "16 Jun 2024"
+            },
+            {
+              text: "21 Jul 2024"
+            },
+            {
+              text:"COVID-19, Flu, Pertussis, RSV"
+            },
+            {
+              html:"<a href='#'> Download (1.2 mbs)</a>"
+            }
+            ]
+        
+        ]
+      }) }}
+
+
+    </div>
+  </div>
+
+
+
+
+
+{% endblock %}

--- a/app/views/reports/v6.html
+++ b/app/views/reports/v6.html
@@ -19,13 +19,13 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-xl">Reports (v6)</h1>
+      <h1 class="nhsuk-heading-xl">Reports</h1>
 
       <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
 
       {{ button({
         "text": "Create report",
-        "href": "/reports/choose-dates"
+        "href": "/reports/choose-dates-1"
       }) }}
 
       {% from 'tables/macro.njk' import table %}

--- a/app/views/reports/v6.html
+++ b/app/views/reports/v6.html
@@ -1,0 +1,107 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Reports
+{% endblock %}
+
+{% block footer %}
+  {{ footer({
+    links: [
+      {
+        "URL": "/regions/v1/setup-test",
+        "label": "Jump forward in time"
+      }
+    ]
+  })}}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <h1 class="nhsuk-heading-xl">Reports (v6)</h1>
+
+      <p class="nhsuk-body-l">Create and run reports from you organisation.</p>
+
+      {{ button({
+        "text": "Create report",
+        "href": "/reports/choose-dates"
+      }) }}
+
+      {% from 'tables/macro.njk' import table %}
+
+      {{ table({
+        panel: false,
+        caption: "Previous reports",
+        firstCellIsHeader: false,
+        head: [
+          {
+            text: "From"
+          },
+          {
+            text: "To"
+          },
+          {
+            text: "Vaccines"
+          },
+          {
+          text: ""
+        }
+
+        ],
+        rows: [
+          [
+            {
+              text: "1 Jan 2024"
+            },
+            {
+              text: "1 Feb 2024"
+            },
+            {
+              text:"COVID-19"
+            },
+            {
+              html:"<a href='#'> Download (200 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "4 Apr 2024"
+            },
+            {
+              text: "4 May 2024"
+            },
+            {
+              text:"COVID-19, Flu"
+            },
+            {
+              html:"<a href='#'> Download (600 kbs)</a>"
+            }
+            ],
+            [
+            {
+              text: "16 Jun 2024"
+            },
+            {
+              text: "21 Jul 2024"
+            },
+            {
+              text:"COVID-19, Flu, Pertussis, RSV"
+            },
+            {
+              html:"<a href='#'> Download (1.2 mbs)</a>"
+            }
+            ]
+        
+        ]
+      }) }}
+
+
+    </div>
+  </div>
+
+
+
+
+
+{% endblock %}

--- a/app/views/vaccines/_header.html
+++ b/app/views/vaccines/_header.html
@@ -1,0 +1,70 @@
+{% block header %}
+
+<!-- This is HTML instead of a macro for now, as the macro doesn't support classes on primary link items -->
+<header class="nhsuk-header nhsuk-header--left" role="banner">
+
+  <div class="nhsuk-header__container">
+    <div class="nhsuk-header__logo"><a class="nhsuk-header__link nhsuk-header__link--service " href="/" aria-label="NHS homepage">
+
+  <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
+    <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v46H0z"></path>
+    <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+  </svg>
+
+        <span class="nhsuk-header__service-name">
+          Record a vaccination
+        </span>
+      </a>
+    </div>
+
+    </div>
+
+    <div class="nhsuk-navigation-container">
+      <nav class="nhsuk-navigation" id="header-navigation" role="navigation" aria-label="Primary navigation">
+        <ul class="nhsuk-header__navigation-list">
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="#">
+              Find a patient
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link app-header__navigation-link--current" href="#">
+              Vaccines
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="/user-admin/v4">
+              Manage users
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item app-header__navigation-item--right-aligned">
+            <a class="nhsuk-header__navigation-link" href="/user-profile/v2">
+              jane.smith@nhs.net
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item ">
+            <a class="nhsuk-header__navigation-link href="#">
+              Sign out
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--home">
+            <a class="nhsuk-header__navigation-link" href="/">
+              Home
+            </a>
+          </li>
+          <li class="nhsuk-mobile-menu-container">
+            <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
+              <span class="nhsuk-u-visually-hidden">Browse</span>
+              More
+              <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </button>
+          <ul class="nhsuk-header__drop-down nhsuk-header__drop-down--hidden"></ul></li>
+        </ul>
+      </nav>
+    </div>
+</header>
+
+{% endblock %}
+

--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -1,0 +1,89 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Add batch
+{% endblock %}
+
+{% block header %}
+  {% include "user-admin/v1/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {{ backLink({ href: "/vaccines/", text: "Back" }) }}
+
+      <h1 class="nhsuks-heading-xl">Add batch</h1>
+
+      <form action="/user-admin/v1/check" method="post" novalidate="true">
+
+        {{ input({
+          "label": {
+            "text": "Batch number"
+          },
+
+          
+          "id": "batch-number",
+          "name": "batchNumber",
+          classes: "nhsuk-input--width-20",
+          value: data.batchNumber
+
+          
+        }) }}
+
+
+        <div class="nhsuk-form-group">
+            <fieldset class="nhsuk-fieldset" aria-describedby="example-hint" role="group">
+              <legend class="nhsuk-fieldset__legend nhsuk-label--l">
+                <h1 class="nhsuk-fieldset__heading">
+                 Expiry date
+                </h1>
+              </legend>
+              <div class="nhsuk-hint" id="example-hint">
+                For example, 15 3 1984
+              </div>
+          
+              <div class="nhsuk-date-input" id="example">
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-day">
+                      Day
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="example-day" name="example-day" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-month">
+                      Month
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="example-month" name="example-month" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-year">
+                      Year
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="example-year" name="example-year" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          
+          </div>
+
+
+
+        {{ button({
+          "text": "Continue"
+      }) }}
+      </form>
+
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/vaccines/check.html
+++ b/app/views/vaccines/check.html
@@ -1,0 +1,91 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Vaccines
+{% endblock %}
+
+{% block header %}
+  {% include "user-admin/v1/_header.html" %}
+{% endblock %}
+
+{% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {{ backLink({ href: "/user-admin/v1/add-email", text: "Back" }) }}
+
+
+      <h1 class="nhsuk-heading-xl">Check and add batch</h1>
+
+      {{ summaryList({
+        rows: [
+          {
+            key: {
+              text: "Name"
+            },
+            value: {
+              text: data.firstName + " " + data.lastName
+            },
+            actions: {
+              items: [
+                {
+                  href: "/user-admin/v1/add-user",
+                  text: "Change",
+                  visuallyHiddenText: "name"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Email address"
+            },
+            value: {
+              html: data["email"]
+            },
+            actions: {
+              items: [
+                {
+                  href: "/user-admin/v1/add-user",
+                  text: "Change",
+                  visuallyHiddenText: "email address"
+                }
+              ]
+            }
+          },
+          {
+            key: {
+              text: "Role"
+            },
+            value: {
+              html: data["role"]
+            },
+            actions: {
+              items: [
+                {
+                  href: "/user-admin/v1/add-user",
+                  text: "Change",
+                  visuallyHiddenText: "role"
+                }
+              ]
+            }
+          }
+        ]
+      }) }}
+
+
+
+
+
+      <form action="/user-admin/v1/add" method="post">
+        {{ button({
+          "text": "Confirm and send"
+        }) }}
+      </form>
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/vaccines/choose-site.html
+++ b/app/views/vaccines/choose-site.html
@@ -1,0 +1,65 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose site
+{% endblock %}
+
+
+{% block header %}
+  {% include "vaccines/_header.html" %}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+
+{{ backLink({ href: "/vaccines/index", text: "Back" }) }}
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+    
+          <h1 class="nhsuk-heading-xl">Choose site</h1>
+    
+          <form action="/regions/v1/organisation-details" method="post">
+    
+          <div class="nhsuk-form-group">
+            <h1 class="nhsuk-label-wrapper">
+              <label class="nhsuk-label nhsuk-label--m nhsuk-u-margin-bottom-1" for="organisationCode">
+            Select a site where you’d like to add a vaccine
+              </label>
+            </h1>
+            <div class="nhsuk-hint" id="organisationName-hint">
+              Search by name or ODS code
+            </div>
+            <select class="nhsuk-select" id="organisationCode" name="organisationCode"
+              data-module="autocomplete" data-autoselect="" data-display-menu="" data-min-length="" data-show-all-values="" data-show-no-options-found="">
+              <option selected value=""></option>
+    
+              {% for code, name in data.nhsTrusts %}
+                <option value="{{ code }}">{{ name }} ({{code }})</option>
+              {% endfor %}
+              {% for code, data in data.nhsPharmacies %}
+                <option value="{{ code }}">{{ data.name }}, {{ data.address }}, {{ data.postcode | upper }} ({{code }})</option>
+              {% endfor %}
+            </select>
+          </div>
+    
+            {{ button({
+              "text": "Continue"
+            }) }}
+          </form>
+    
+    
+        </div>
+      </div>
+
+
+
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/views/vaccines/choose-site.html
+++ b/app/views/vaccines/choose-site.html
@@ -47,10 +47,12 @@
             </select>
           </div>
     
-            {{ button({
-              "text": "Continue"
-            }) }}
-          </form>
+          {{ button({
+            "text": "Continue",
+            "href": "/vaccines/choose-vaccine"
+          }) }}
+
+        </form>
     
     
         </div>

--- a/app/views/vaccines/choose-vaccine.html
+++ b/app/views/vaccines/choose-vaccine.html
@@ -1,0 +1,72 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Choose vaccine
+{% endblock %}
+
+
+{% block header %}
+  {% include "vaccines/_header.html" %}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+   
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+          {{ backLink({ href: "/vaccines/choose-site", text: "Back" }) }}
+    
+          <h1 class="nhsuks-heading-xl">Choose vaccine</h1>
+          <p class="nhsuk-body-l">Add and edit your vaccines.</p>
+    
+          <form action="/user-admin/v1/check" method="post" novalidate="true">
+    
+        
+            <div class="nhsuk-form-group">
+
+                <fieldset class="nhsuk-fieldset">
+                  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+                  </legend>
+              
+                  <div class="nhsuk-radios">
+              
+                    <div class="nhsuk-radios__item">
+                      <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+                      <label class="nhsuk-label nhsuk-radios__label" for="example-1">
+                        COVID-19
+                      </label>
+                    </div>
+              
+                    <div class="nhsuk-radios__item">
+                      <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no">
+                      <label class="nhsuk-label nhsuk-radios__label" for="example-2">
+                        Flu
+                      </label>
+                    </div>
+              
+                  </div>
+                </fieldset>
+              
+              </div>
+    
+    
+            {{ button({
+              "text": "Continue"
+          }) }}
+          </form>
+    
+    
+        </div>
+      </div>
+    
+
+
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/app/views/vaccines/edit-batch.html
+++ b/app/views/vaccines/edit-batch.html
@@ -1,0 +1,89 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Add batch
+{% endblock %}
+
+{% block header %}
+  {% include "user-admin/v1/_header.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {{ backLink({ href: "/vaccines/choose-vaccine", text: "Back" }) }}
+
+      <h1 class="nhsuks-heading-xl">Edit batch</h1>
+
+      <form action="/user-admin/v1/check" method="post" novalidate="true">
+
+        {{ input({
+          "label": {
+            "text": "Batch number"
+          },
+
+          
+          "id": "batch-number",
+          "name": "batchNumber",
+          classes: "nhsuk-input--width-20",
+          value: data.batchNumber
+
+          
+        }) }}
+
+
+        <div class="nhsuk-form-group">
+            <fieldset class="nhsuk-fieldset" aria-describedby="example-hint" role="group">
+              <legend class="nhsuk-fieldset__legend nhsuk-label--l">
+                <h1 class="nhsuk-fieldset__heading">
+                 Expiry date
+                </h1>
+              </legend>
+              <div class="nhsuk-hint" id="example-hint">
+                For example, 15 3 1984
+              </div>
+          
+              <div class="nhsuk-date-input" id="example">
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-day">
+                      Day
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="example-day" name="example-day" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-month">
+                      Month
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="example-month" name="example-month" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <div class="nhsuk-form-group">
+                    <label class="nhsuk-label nhsuk-date-input__label" for="example-year">
+                      Year
+                    </label>
+                    <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="example-year" name="example-year" type="text" pattern="[0-9]*" inputmode="numeric">
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          
+          </div>
+
+
+
+        {{ button({
+          "text": "Continue"
+      }) }}
+      </form>
+
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -1,0 +1,40 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Vaccines
+{% endblock %}
+
+
+{% block header %}
+  {% include "vaccines/_header.html" %}
+{% endblock %}
+
+
+
+
+
+{% block content %}
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+    
+          <h1 class="nhsuk-heading-xl">Vaccines</h1>
+    
+          <p class="nhsuk-body-l">Add and edit your vaccines.</p>
+    
+          {{ button({
+            "text": "Add vaccines",
+            "href": "/vaccines/choose-site"
+          }) }}
+    
+        </div>
+      </div>
+
+
+
+
+
+
+    </div>
+  </div>
+{% endblock %}
+


### PR DESCRIPTION
Add some different options (from most basic to slightly-less-basic) for extracting data:

<img width="707" alt="Screenshot 2024-07-12 at 13 53 17" src="https://github.com/user-attachments/assets/3700fde3-f725-4398-8fab-d4e448096e90">

## Screenshots

### Simplest (single button)

<img width="1013" alt="Screenshot 2024-07-12 at 13 54 04" src="https://github.com/user-attachments/assets/2827fa88-ad8f-40e3-b718-f0d4d279651a">

### Date filter

<img width="1019" alt="Screenshot 2024-07-12 at 13 54 58" src="https://github.com/user-attachments/assets/c8585cdb-bc2a-499f-a0be-e444ba6a53d6">

### Date filter + personal details checkbox

<img width="1005" alt="Screenshot 2024-07-12 at 13 55 24" src="https://github.com/user-attachments/assets/14e3c98f-ff74-45a7-b2b0-d30fdf9fc0a8">

### Date filter + storing previous extracts for re-download

<img width="960" alt="Screenshot 2024-07-12 at 13 55 50" src="https://github.com/user-attachments/assets/98ed296a-1d78-49ef-ba5b-0fe07d8c941a">

### As above, but with a location filter

<img width="632" alt="Screenshot 2024-07-12 at 13 56 26" src="https://github.com/user-attachments/assets/b212ffa8-bc4c-4980-b5b8-186bb484f8b0">

### As above, but with eligibility filter

<img width="912" alt="Screenshot 2024-07-12 at 13 56 57" src="https://github.com/user-attachments/assets/c3150600-220a-4fbf-bc6f-9d4c399640d3">
