### PR TITLE
Removed reference to lead users and included hint text

### DIFF
--- a/app/views/regions/v1/add-email.html
+++ b/app/views/regions/v1/add-email.html
@@ -21,7 +21,7 @@
 
       <p>Choose a user at {{ organisation.name }} to receive instructions about creating an account.</p>
 
-      <p>It's their responsibility to set up and add their organisation’s users and vaccination sites.</p>
+      <p>It’s their responsibility to set up and add their organisation’s users and vaccination sites.</p>
 
       <form action="/regions/v1/check-and-send" method="post" novalidate>
         

--- a/app/views/regions/v1/add-email.html
+++ b/app/views/regions/v1/add-email.html
@@ -17,11 +17,11 @@
     <div class="nhsuk-grid-column-two-thirds">
 
 
-      <h1 class="nhsuk-heading-l">Add a lead user</h1>
+      <h1 class="nhsuk-heading-l">Add a user</h1>
 
-      <p>Choose a lead user for {{ organisation.name }} to receive instructions about creating an NHS Record a vaccination account.</p>
+      <p>Choose a user at {{ organisation.name }} to receive instructions about creating an account.</p>
 
-      <p>A lead user is responsible for adding their organisation’s users and vaccination sites.</p>
+      <p>It's their responsibility to set up and add their organisation’s users and vaccination sites.</p>
 
       <form action="/regions/v1/check-and-send" method="post" novalidate>
         


### PR DESCRIPTION
Hint text for the email address field.

'Must be a personal email account (not shared).'

## Description

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
