### PR TITLE
Log errors to terminal

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,9 +61,9 @@ function compileAssets() {
 function startNodemon(done) {
   const server = nodemon({
     script: 'app.js',
-    stdout: false,
+    stdout: true,
     ext: 'js',
-    quiet: true,
+    quiet: false,
   });
   let starting = false;
 


### PR DESCRIPTION
Applies the changes from https://github.com/nhsuk/nhsuk-prototype-kit/pull/329 to enable errors to be shown in the Terminal rather than being swallowed up.

Thanks to @Fenwick17 for spotting this!

