### PR TITLE
Update logic if adding a deactivated user

### DIFF
--- a/app/routes/user-admin.js
+++ b/app/routes/user-admin.js
@@ -165,6 +165,20 @@ module.exports = (router) => {
     })
   })
 
+  router.get('/user-admin/v4/check', (req, res) => {
+
+    const data = req.session.data;
+    const {email} = data;
+    let existingUserWithSameEmail = false
+    if (email) {
+      existingUserWithSameEmail = data.users.find((user) => user.email === email)
+    }
+
+    res.render('user-admin/v4/check', {
+      existingUserWithSameEmail
+    })
+  })
+
   router.get('/user-admin/v4/:id/deactivate', (req, res) => {
 
     const data = req.session.data;
@@ -231,13 +245,8 @@ module.exports = (router) => {
       emailError = 'Enter NHS email address'
     } else if (!(email.endsWith('nhs.net') || email.endsWith('.nhs.uk'))) {
       emailError = 'Email address must be an NHS email'
-    } else if (existingUserWithSameEmail) {
-      if (existingUserWithSameEmail.status == 'Deactivated') {
-        emailError = 'NHS email address belongs to a deactivated user. Reactivate this account. '
-      } else {
-        emailError = 'NHS email address already added as a user'
-      }
-
+    } else if (existingUserWithSameEmail && existingUserWithSameEmail.status !== 'Deactivated') {
+      emailError = 'NHS email address already added as a user'
     }
 
     if (!role || role === '') {
@@ -263,15 +272,33 @@ module.exports = (router) => {
 
   // Adding a user - V4
   router.post('/user-admin/v4/add', (req, res) => {
-    req.session.data.users.push({
-      id: Math.floor(Math.random() * 10000000).toString(),
-      firstName: req.session.data.firstName,
-      lastName: req.session.data.lastName,
-      email: req.session.data.email,
-      role: req.session.data.role,
-      clinician: req.session.data.clinician,
-      status: 'Invited'
-    })
+
+    const data = req.session.data
+    const {firstName, lastName, email, role, clinician} = data
+
+    const existingUserWithSameEmail = data.users.find((user) => user.email === email)
+
+
+    if (existingUserWithSameEmail) {
+
+      // Update existing user instead
+      existingUserWithSameEmail.firstName = firstName
+      existingUserWithSameEmail.lastName = lastName
+      existingUserWithSameEmail.role = role
+      existingUserWithSameEmail.clinician = clinician
+      existingUserWithSameEmail.status = 'Active'
+
+    } else {
+      req.session.data.users.push({
+        id: Math.floor(Math.random() * 10000000).toString(),
+        firstName: req.session.data.firstName,
+        lastName: req.session.data.lastName,
+        email: req.session.data.email,
+        role: req.session.data.role,
+        clinician: req.session.data.clinician,
+        status: 'Invited'
+      })
+    }
 
     // Reset data
     req.session.data.email = ''

--- a/app/routes/user-admin.js
+++ b/app/routes/user-admin.js
@@ -168,13 +168,15 @@ module.exports = (router) => {
   router.get('/user-admin/v4/check', (req, res) => {
 
     const data = req.session.data;
-    const {email} = data;
+    const {email, firstName, lastName} = data;
     let existingUserWithSameEmail = false
     if (email) {
       existingUserWithSameEmail = data.users.find((user) => user.email === email)
     }
 
     res.render('user-admin/v4/check', {
+      firstName,
+      lastName,
       existingUserWithSameEmail
     })
   })

--- a/app/views/user-admin/v4/_reactivation-email.html
+++ b/app/views/user-admin/v4/_reactivation-email.html
@@ -1,0 +1,13 @@
+<p>From: ravs@england.nhs.uk<br>
+Subject: Reactivated account: NHS Record a vaccination service (RAVS)
+</p>
+<hr>
+
+<p>Hi {{ firstName}} {{ lastName}},</p>
+
+<p>We’ve reactivated your NHS Record a vaccination account. You can sign in using your Okta account.</p>
+
+<p><a href="https://nhsi.okta-emea.com/">Reset your Okta password</a> if you need to.</p>
+
+<p>Many thanks,<br>
+NHS Record a vaccination</p>

--- a/app/views/user-admin/v4/_welcome-email.html
+++ b/app/views/user-admin/v4/_welcome-email.html
@@ -1,0 +1,35 @@
+<p>From: ravs@england.nhs.uk<br>
+Subject: RAVS (Record a vaccination service) Get started
+</p>
+<hr>
+
+<p>Dear RAVS users,</p>
+
+<p><b>Get started</b></p>
+
+<p>We’ve created an Okta account for you to securely access the NHS Record a vaccination service (RAVS).</p>
+
+<p>Here’s what you need to do:</p>
+
+<p><b>1. Activate your Okta account</b></p>
+<p>You’ll receive a ‘Welcome to Okta’ email (from noreply@okta.com). Please activate the link within 7 days.</p>
+
+<p>If you cannot find the email, please check your spam or junk.</p>
+
+<p><b>2. Log in to RAVS</b></p>
+
+<p>Once you’ve activated your Okta account, log in to <a href="#">www.ravs.england.nhs.uk</a> using your Okta username and password.</p>
+
+<p>You can also access RAVS through your Okta account by clicking ‘RAVS (PROD) app’.</p>
+
+<p>Many thanks,<br>
+NHS Record a vaccination</p>
+
+<p><b>Guidance</b></p>
+<p>Visit: <a href="#">www.guide.ravs.england.nhs.uk</a>.</p>
+
+<p><b>Helpdesk</b></p>
+
+<p>Email: <a href="#">ravs.support@england.nhs.uk</a><br>
+Telephone: 0121 611 0187 (select option 3)<br>
+Monday to Friday: 8am to 6pm. Weekends: 8am to 4pm</p>

--- a/app/views/user-admin/v4/check.html
+++ b/app/views/user-admin/v4/check.html
@@ -22,8 +22,6 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-
-
       <h1 class="nhsuk-heading-xl">Check and add user</h1>
 
       {{ summaryList({
@@ -100,46 +98,18 @@
       }) }}
 
 
-      <p>{{ data.firstName }} will be sent this welcome email with information about activating an account:</p>
+      {% if existingUserWithSameEmail %}
+        <p>{{ data.firstName }} will be re-activated and sent this email:</p>
+      {% else %}
+        <p>{{ data.firstName }} will be sent this welcome email with information about activating an account:</p>
+      {% endif %}
 
       <div class="app-email-preview">
-        <p>From: ravs@england.nhs.uk<br>
-        Subject: RAVS (Record a vaccination service) Get started
-        </p>
-        <hr>
-
-        <p>Dear RAVS users,</p>
-
-        <p><b>Get started</b></p>
-
-        <p>We’ve created an Okta account for you to securely access the NHS Record a vaccination service (RAVS).</p>
-
-        <p>Here’s what you need to do:</p>
-
-        <p><b>1. Activate your Okta account</b></p>
-        <p>You’ll receive a ‘Welcome to Okta’ email (from noreply@okta.com). Please activate the link within 7 days.</p>
-
-        <p>If you cannot find the email, please check your spam or junk.</p>
-
-        <p><b>2. Log in to RAVS</b></p>
-
-        <p>Once you’ve activated your Okta account, log in to <a href="#">www.ravs.england.nhs.uk</a> using your Okta username and password.</p>
-
-        <p>You can also access RAVS through your Okta account by clicking ‘RAVS (PROD) app’.</p>
-
-        <p>Many thanks,<br>
-        NHS Record a vaccination</p>
-
-        <p><b>Guidance</b></p>
-        <p>Visit: <a href="#">www.guide.ravs.england.nhs.uk</a>.</p>
-
-        <p><b>Helpdesk</b></p>
-
-        <p>Email: <a href="#">ravs.support@england.nhs.uk</a><br>
-        Telephone: 0121 611 0187 (select option 3)<br>
-        Monday to Friday: 8am to 6pm. Weekends: 8am to 4pm</p>
-
-
+        {% if existingUserWithSameEmail %}
+          {% include "user-admin/v4/_reactivation-email.html" %}
+        {% else %}
+          {% include "user-admin/v4/_welcome-email.html" %}
+        {% endif %}
       </div>
 
 

--- a/app/views/user-admin/v4/check.html
+++ b/app/views/user-admin/v4/check.html
@@ -22,7 +22,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Check and add user</h1>
+      <h1 class="nhsuk-heading-xl">Check and {% if existingUserWithSameEmail %}reactivate{% else %}add{% endif %} user</h1>
 
       {{ summaryList({
         rows: [

--- a/app/views/user-admin/v4/index.html
+++ b/app/views/user-admin/v4/index.html
@@ -53,9 +53,7 @@
               <td class="nhsuk-table__cell ">{{ user.role }}</td>
               <td class="nhsuk-table__cell ">{{ user.status }}</td>
               <td class="nhsuk-table__cell">
-                <a href="/user-admin/v4/users/{{ user.id }}/change-role" class="nhsuk-link">Change</a>
-
-                <!-- <a href="/user-admin/v4/users/{{ user.id }}/change-role" class="nhsuk-link">Deactivate</a> -->
+                <a href="/user-admin/v4/users/{{ user.id }}/change-role" class="nhsuk-link">Change <span class="nhsuk-u-visually-hidden">details for {{ user.firstName }} </span></a>
               </td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
Following a great suggestion from Ileri, this updates the logic when adding a new user with the same email address as a deactivated user (maybe you forgot they were previously at your organisation, and didn't check the list).

## Before

Previously this would show an error message:

<img width="887" alt="Screenshot 2024-08-30 at 11 16 26" src="https://github.com/user-attachments/assets/b05ad3fd-a22c-4a2d-9ac7-b397ceb20959">

## After

The updated flow will let you continue instead, and makes it clear on the confirmation page that you're reactivating a previous user rather than creating a new one.

The existing user will also be updated if the permission level, clinician status or name was changed.

![check-and-reactivate](https://github.com/user-attachments/assets/a8bec2d9-0dcf-4b4d-8b1f-6aad49d86b0d)

