### PR TITLE
Allow users to deactivate themselves

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -34,7 +34,7 @@ module.exports = {
       email: "mavis.patricia@nhs.net",
       firstName: "Mavis",
       lastName: "Patricia",
-      role: "Recorder",
+      role: "Lead administrator",
       status: "Active",
       clinician: "yes"
     },

--- a/app/routes/user-admin.js
+++ b/app/routes/user-admin.js
@@ -22,7 +22,6 @@ module.exports = (router) => {
   // Editing a user’s role
   router.get('/user-admin/v1/users/:id/change-role', (req, res) => {
     const { id } = req.params
-
     const user = req.session.data.users.find((user) => user.id === id)
 
     res.render('user-admin/v1/change-role', {
@@ -198,7 +197,12 @@ module.exports = (router) => {
     user.status = 'Deactivated'
     user.deactivatedDate = new Date().toISOString().substring(0,10)
 
-    res.redirect('/user-admin/v4/deactivated')
+    if (data.currentUserId === user.id) {
+      // User deactivated themself
+      res.redirect('/')
+    } else {
+      res.redirect('/user-admin/v4/deactivated')
+    }
   })
 
   router.get('/user-admin/v4/:id/reactivate', (req, res) => {
@@ -317,10 +321,13 @@ module.exports = (router) => {
   router.get('/user-admin/v4/users/:id/change-role', (req, res) => {
     const { id } = req.params
 
+    const numberOfLeadAdmins = req.session.data.users.filter((user) => (user.role === 'Lead administrator') && (user.status !== 'Deactivated')).length
+
     const user = req.session.data.users.find((user) => user.id === id)
 
     res.render('user-admin/v4/change', {
-      user
+      user,
+      numberOfLeadAdmins
     })
   })
 

--- a/app/views/user-admin/v4/change.html
+++ b/app/views/user-admin/v4/change.html
@@ -91,8 +91,16 @@
       }) }}
       </form>
 
-      <p>Do they still need an account? <a href="/user-admin/v4/{{ user.id }}/deactivate">Deactivate this account</a></p>
 
+      {% if user.id === currentUser.id %}
+        {% if numberOfLeadAdmins > 1 %}
+          <p>Do you still need this account? <a href="/user-admin/v4/{{ user.id }}/deactivate">Deactivate your account</a></p>
+        {% else %}
+          <p>You cannot deactivate your account as you are the only active lead administrator.</p>
+        {% endif %}
+      {% else %}
+        <p>Do they still need an account? <a href="/user-admin/v4/{{ user.id }}/deactivate">Deactivate this account</a></p>
+      {% endif %}
 
     </div>
   </div>

--- a/app/views/user-admin/v4/deactivate.html
+++ b/app/views/user-admin/v4/deactivate.html
@@ -20,13 +20,26 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Deactivate {{ user.firstName }} {{ user.lastName }}</h1>
+      {% if user.id === currentUser.id %}
 
-      <p>Once you deactivate {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they can no longer sign in and use NHS Record a vaccination. They’ll receive an email to confirm their account has been deactivated.</p>
+        <h1 class="nhsuk-heading-l">Deactivate your account</h1>
 
-      <p>Their Okta account will remain active, so they can continue to access other services.</p>
+        <p>Once you deactivate your account, you will be signed out and can no longer sign in and use NHS Record a vaccination.</p>
 
-      <p>You can reactivate their account anytime.</p>
+        <p>Your Okta account will remain active, so you can continue to access other services.</p>
+
+        <p>Another lead admin can reactivate your account anytime.</p>
+
+      {% else %}
+
+        <h1 class="nhsuk-heading-l">Deactivate {{ user.firstName }} {{ user.lastName }}</h1>
+
+        <p>Once you deactivate {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they can no longer sign in and use NHS Record a vaccination. They’ll receive an email to confirm their account has been deactivated.</p>
+
+        <p>Their Okta account will remain active, so they can continue to access other services.</p>
+
+        <p>You can reactivate their account anytime.</p>
+      {% endif %}
 
       <form action="/user-admin/v4/{{ user.id }}/deactivate" method="post" novalidate="true">
         {{ button({

--- a/app/views/user-admin/v4/deactivate.html
+++ b/app/views/user-admin/v4/deactivate.html
@@ -24,7 +24,7 @@
 
         <h1 class="nhsuk-heading-l">Deactivate your account</h1>
 
-        <p>Once you deactivate your account, you will be signed out and can no longer sign in and use NHS Record a vaccination.</p>
+        <p>Once you deactivate your account, you’ll be signed out and cannot sign in and use NHS Record a vaccination.</p>
 
         <p>Your Okta account will remain active, so you can continue to access other services.</p>
 
@@ -34,7 +34,7 @@
 
         <h1 class="nhsuk-heading-l">Deactivate {{ user.firstName }} {{ user.lastName }}</h1>
 
-        <p>Once you deactivate {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they can no longer sign in and use NHS Record a vaccination. They’ll receive an email to confirm their account has been deactivated.</p>
+        <p>Once you deactivate {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they cannot sign in and use NHS Record a vaccination. They’ll receive an email to confirm their account has been deactivated.</p>
 
         <p>Their Okta account will remain active, so they can continue to access other services.</p>
 


### PR DESCRIPTION
This adds some logic so that:

* users cannot deactivate their own account if they are the only active lead administrator for their organisation
* if there are other active lead administrators, they can deactivate their own account, and the content is slightly changed
* after deactivating your own account, you are signed out and return to the homepage

## Screenshots

### Deactivating your own account (confirmation screen)

![deactivate-yourself](https://github.com/user-attachments/assets/4795bc5e-c7ab-431f-8e25-7f47ca43123c)

### Being unable to deactivate your own account

<img width="681" alt="Screenshot 2024-08-30 at 13 30 07" src="https://github.com/user-attachments/assets/66cb7df0-d47d-490a-a8af-876e3e33335a">
