### PR TITLE
Allow regions to uninvite users

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -94,6 +94,75 @@ module.exports = {
       clinician: "no"
     }
   ],
+  organisationsAdded: [
+    {
+      code: 'RD8',
+      name: 'Milton Keynes University Hospital NHS Foundation Trust',
+      address: {
+        line1: 'Standing Way, Eaglestone',
+        town: 'Milton Keynes',
+        postcode: 'MK6 5LD'
+      },
+      type: 'NHS Trust',
+      status: 'Active',
+      leadUsers: [
+        {
+          id: "36479285",
+          email: 'sarah.jane@mk.nhs.net',
+          status: 'Active',
+          firstName: 'Sarah',
+          lastName: 'Jane'
+        },
+        {
+          id: "6363462",
+          email: 'joseph.darling@mk.nhs.net',
+          status: 'Invited',
+          firstName: 'Joseph',
+          lastName: 'Darling'
+        }
+      ]
+    },
+    {
+      code: 'RAJ',
+      name: 'Mid and South Essex NHS Foundation Trust',
+      address: {
+        line1: 'Prittlewell Chase',
+        town: 'Westcliffe-on-Sea',
+        postcode: 'SS0 0RY'
+      },
+      type: 'NHS Trust',
+      status: 'Active',
+      leadUsers: [
+        {
+          id: "9476731",
+          firstName: 'Richard',
+          lastName: 'Jones',
+          email: 'richard.jones@mid-essex.nhs.net',
+          status: 'Active'
+        }
+      ]
+    },
+    {
+      code: 'FA424',
+      name: 'Pickfords Pharmacy',
+      address: {
+        line1: '8 Spencer Court',
+        town: 'Corby',
+        postcode: 'NN17 1NU'
+      },
+      type: 'Community Pharmacy',
+      status: 'Invited',
+      leadUsers: [
+        {
+          id: "634636",
+          firstName: 'Sara',
+          lastName: 'Pickford',
+          email: 'sara.pickford@pickford-pharmacy.com',
+          status: 'Invited'
+        }
+      ]
+    }
+  ],
   "nhsTrusts": {
     "R0A": "Manchester University NHS Foundation Trust",
     "R0B": "South Tyneside and Sunderland NHS Foundation Trust",

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -84,7 +84,7 @@
       <h2>NHS regions interface</h2>
 
       <ul>
-        <li><a href="/regions/v1">Version 1</a></li>
+        <li><a href="/regions/v1">Regions interface</a></li>
       </ul>
 
 

--- a/app/views/regions/v1/index.html
+++ b/app/views/regions/v1/index.html
@@ -4,16 +4,6 @@
   East of England region
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
-{% endblock %}
 
 {% block content %}
   <div class="nhsuk-grid-row">

--- a/app/views/regions/v1/organisation.html
+++ b/app/views/regions/v1/organisation.html
@@ -28,7 +28,7 @@
   </div>
 
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-three-quarters">
+    <div class="nhsuk-grid-column-full">
 
       {% if (organisation.leadUsers | length) > 0 %}
         <table class="nhsuk-table">
@@ -61,9 +61,9 @@
                 <td class="nhsuk-table__cell ">
                   {{ leadUser.status }}
                 </td>
-                <td class="nhsuk-table__cell ">
-                  {% if leadUser.status == 'Invite' %}
-                    <a href="#">Resend invitation</a>
+                <td class="nhsuk-table__cell app-table__cell--right-aligned">
+                  {% if leadUser.status == 'Invited' %}
+                    <a href="/regions/v1/organisations/{{ organisation.code }}/users/{{ leadUser.id }}/uninvite">Uninvite</a>
                   {% endif %}
                 </td>
               </tr>

--- a/app/views/regions/v1/uninvite.html
+++ b/app/views/regions/v1/uninvite.html
@@ -1,16 +1,12 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Add user
-{% endblock %}
-
-{% block header %}
-  {% include "user-admin/v4/_header.html" %}
+  Uninvite {{ user.firstName }} {{ user.lastName }}
 {% endblock %}
 
 {% block outerContent %}
   {{ backLink({
-    href: "/user-admin/v4/users/" + user.id + "/change-role",
+    href: "/regions/v1/organisations/" + organisation.code,
     text: "Back",
     classes: "nhsuk-u-margin-top-4"
   }) }}
@@ -22,13 +18,18 @@
 
       <h1 class="nhsuk-heading-l">Uninvite {{ user.firstName }} {{ user.lastName }}</h1>
 
-      <p>Once you uninvite {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they can no longer sign in and use NHS Record a vaccination. They’ll receive an email to confirm their account has been deactivated.</p>
+
+      {% if numberOfActiveUsers === 0 %}
+        <p><strong>{{ organisation.name }} will be removed</strong></p>
+      {% endif %}
+
+      <p>Once you uninvite {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they cannot sign in and use NHS Record a vaccination.</p>
 
       <p>You can reinvite this person anytime.</p>
 
-      <form action="/user-admin/v4/{{ user.id }}/deactivate" method="post" novalidate="true">
+      <form action="/regions/v1/organisations/{{ organisation.code }}/users/{{ user.id }}/uninvited" method="post" novalidate="true">
         {{ button({
-          "text": "Deactivate",
+          "text": "Confirm, uninvite user",
           classes: "nhsuk-button--warning"
         }) }}
       </form>

--- a/app/views/regions/v1/uninvite.html
+++ b/app/views/regions/v1/uninvite.html
@@ -21,9 +21,14 @@
 
       {% if numberOfActiveUsers === 0 %}
         <p><strong>{{ organisation.name }} will be removed</strong></p>
+
+        <p>{{ user.firstName }} {{ user.lastName }} ({{ user.email}}) is the only user for their organisation. Once you uninvite them, they cannot sign in and use NHS Record a vaccination.</p>
+      {% else %}
+
+        <p>Once you uninvite {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they cannot sign in and use NHS Record a vaccination.</p>
+
       {% endif %}
 
-      <p>Once you uninvite {{ user.firstName }} {{ user.lastName }} ({{ user.email}}), they cannot sign in and use NHS Record a vaccination.</p>
 
       <p>You can reinvite this person anytime.</p>
 

--- a/app/views/reports/download.html
+++ b/app/views/reports/download.html
@@ -4,17 +4,6 @@
   Reports
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
-{% endblock %}
-
 {% block content %}
 
 {{ backLink({ href: "/reports/check-2", text: "Back" }) }}

--- a/app/views/reports/v5.html
+++ b/app/views/reports/v5.html
@@ -4,16 +4,6 @@
   Reports
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
-{% endblock %}
 
 {% block content %}
   <div class="nhsuk-grid-row">
@@ -92,7 +82,7 @@
               html:"<a href='#'> Download (1.2 mbs)</a>"
             }
             ]
-        
+
         ]
       }) }}
 

--- a/app/views/reports/v6.html
+++ b/app/views/reports/v6.html
@@ -4,17 +4,6 @@
   Reports
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
-{% endblock %}
-
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
@@ -92,7 +81,7 @@
               html:"<a href='#'> Download (1.2 mbs)</a>"
             }
             ]
-        
+
         ]
       }) }}
 

--- a/app/views/reports/v7.html
+++ b/app/views/reports/v7.html
@@ -4,17 +4,6 @@
   Reports
 {% endblock %}
 
-{% block footer %}
-  {{ footer({
-    links: [
-      {
-        "URL": "/regions/v1/setup-test",
-        "label": "Jump forward in time"
-      }
-    ]
-  })}}
-{% endblock %}
-
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">


### PR DESCRIPTION
This adds an additional feature to the regions interface which would allow them to 'uninvite' a user, for example if accidentally inviting the wrong person.

Only users who have never signed in to the service could be uninvited. Users who have accessed the service would have to be deactivated by their organisation instead (as we may need to keep their user record for reporting and auditing purposes).

If user is uninvited who is the only user left who had been invited to that organisation, then the organisation itself is also removed. This avoids 'empty' organisations remaining in the organisations list, which may have been the wrong organisation invited.

## Screenshots

### User list showing Uninvite link

<img width="1062" alt="Screenshot 2024-09-02 at 15 21 21" src="https://github.com/user-attachments/assets/cea36b45-cae5-4230-840f-20abf11f49d3">

### Uninvite confirmation page

<img width="1011" alt="Screenshot 2024-09-02 at 15 21 33" src="https://github.com/user-attachments/assets/03bcd72a-6842-4871-837e-50b27ec4d5fa">

### Uninvite confirmation page where the organisation would also be removed

<img width="1012" alt="Screenshot 2024-09-02 at 15 55 16" src="https://github.com/user-attachments/assets/573b73b4-1a6b-4749-8932-1b7fa0939524">


