### PR TITLE
Fix permission description in user profile

### DIFF
--- a/app/views/user-profile/v2/index.html
+++ b/app/views/user-profile/v2/index.html
@@ -13,7 +13,15 @@
 
         {% set permissionLevelHtml %}
           <div>{{ currentUser.role }}</div>
-          <p class="app-summary__explanation">Can record vaccinations, and manage vaccine products and batches</p>
+          <p class="app-summary__explanation">
+            {% if currentUser.role == "Lead administrator" %}
+              Can record vaccinations, create reports, manage vaccines and users
+            {% elseif currentUser.role == "Administrator" %}
+              Can record vaccinations, create reports and manage vaccines
+            {% elseif currentUser.role == "Recorder" %}
+              Can record vaccinations only
+            {% endif %}
+          </p>
         {% endset %}
 
         {{ summaryList({
@@ -69,9 +77,12 @@
 
         <p>Only lead administrators can change permission levels. The lead administrators for Southampton NHS Trust are:</p>
 
-        <ul class="nhsuk-list">
-          <li>Jane Smith (jane.smith@trustname.nhs.uk)</li>
-          <li>John Jones (john.jones4@trustname.nhs.uk)</li>
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          {% for user in data.users %}
+            {% if user.role == "Lead administrator" and user.status == "Active" %}
+              <li>{{ user.firstName }} {{ user.lastName }} ({{ user.email }})</li>
+            {% endif %}
+          {% endfor %}
         </ul>
 
       {% endif %}


### PR DESCRIPTION
Updates permission level description on the user profile page. Also updates the list of lead administrator (displayed only if you are not a lead administrator yourself) to use bullets, and be dynamic based on data.

## Screenshots

### Lead administrator

<img width="729" alt="Screenshot 2024-09-04 at 15 23 39" src="https://github.com/user-attachments/assets/652613a8-6018-41ea-ade1-d4755338a3d2">

## Administrator

<img width="869" alt="Screenshot 2024-09-04 at 15 24 43" src="https://github.com/user-attachments/assets/71ac7ecc-4c46-4183-9de7-89be43f5d541">

## Recorder

<img width="941" alt="Screenshot 2024-09-04 at 15 25 11" src="https://github.com/user-attachments/assets/4df56c8a-8c04-4f53-9e5d-e81e589ddbb3">

