### PR TITLE
Default to all data option selected in Reports

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -172,6 +172,9 @@ module.exports = {
     {name: "South East", code: "SE1"},
     {name: "London", code: "LO1"},
   ],
+  data: [
+    "Patients", "Staff", "Site or delivery team", "Assessment and consent", "Vaccination"
+  ],
   "nhsTrusts": {
     "R0A": "Manchester University NHS Foundation Trust",
     "R0B": "South Tyneside and Sunderland NHS Foundation Trust",

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -86,6 +86,26 @@ module.exports = (router) => {
 
   })
 
+  router.post('/reports/update-data', (req, res) => {
+
+    const dataSelected = req.session.data.data || []
+
+    if (dataSelected.length > 0) {
+      res.redirect('/reports/check')
+    } else {
+
+      const error = {
+        text: "Select data for report",
+        href: "#data-1"
+      }
+
+      res.render('reports/choose-data', {
+        error
+      })
+    }
+
+  })
+
 
   router.get('/reports/check', (req, res) => {
 

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -19,67 +19,74 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form action="/reports/check" method="post" novalidate="true">
+      {% if error %}
+        {{ errorSummary({
+          titleText: "There is a problem",
+          errorList: [error]
+        }) }}
+      {% endif %}
 
-        {% from 'checkboxes/macro.njk' import checkboxes %}
+      <form action="/reports/update-data" method="post" novalidate="true">
 
-        <form>
-          {{ checkboxes({
-            idPrefix: "data",
-            name: "data",
-            fieldset: {
-              legend: {
-                text: "Choose data",
-                isPageHeading: true,
-                classes: "nhsuk-fieldset__legend--xl"
+        {{ checkboxes({
+          idPrefix: "data",
+          name: "data",
+          errorMessage: {
+            text: error.text
+          } if error,
+          fieldset: {
+            legend: {
+              text: "Choose data",
+              isPageHeading: true,
+              classes: "nhsuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "Patients",
+              text: "Patients",
+              checked: (data.data | arrayOrStringIncludes("Patients")),
+              hint: {
+                text: "NHS number, name, date of birth, gender, address"
               }
             },
-            items: [
-              {
-                value: "Patients",
-                text: "Patients",
-                checked: (data.data | arrayOrStringIncludes("Patients")),
-                hint: {
-                  text: "NHS number, name, date of birth, gender, address"
-                }
-              },
-              {
-                value: "Staff",
-                text: "Staff",
-                checked: (data.data | arrayOrStringIncludes("Staff")),
-                hint: {
-                  text: "Recorder, vaccinator, assessing and consenting clinician names and email addresses"
-                }
-              },
-              {
-                value: "Site or delivery team",
-                text: "Site or delivery team",
-                checked: (data.data | arrayOrStringIncludes("Site or delivery team")),
-                hint: {
-                  text: "Names and ODS codes"
-                }
-              },{
-                value: "Assessment and consent",
-                text: "Assessment and consent",
-                checked: (data.data | arrayOrStringIncludes("Assessment and consent")),
-                hint: {
-                  text: "Vaccinated and not givens, date, consent and eligibility details, and comments"
-                }
-              },{
-                value: "Vaccination",
-                text: "Vaccination",
-                checked: (data.data | arrayOrStringIncludes("Vaccination")),
-                hint: {
-                  text: "Date, vaccine details and dose given, site of body, legal mechanism and comments"
-                }
+            {
+              value: "Staff",
+              text: "Staff",
+              checked: (data.data | arrayOrStringIncludes("Staff")),
+              hint: {
+                text: "Recorder, vaccinator, assessing and consenting clinician names and email addresses"
               }
-            ]
-          }) }}
+            },
+            {
+              value: "Site or delivery team",
+              text: "Site or delivery team",
+              checked: (data.data | arrayOrStringIncludes("Site or delivery team")),
+              hint: {
+                text: "Names and ODS codes"
+              }
+            },{
+              value: "Assessment and consent",
+              text: "Assessment and consent",
+              checked: (data.data | arrayOrStringIncludes("Assessment and consent")),
+              hint: {
+                text: "Vaccinated and not givens, date, consent and eligibility details, and comments"
+              }
+            },{
+              value: "Vaccination",
+              text: "Vaccination",
+              checked: (data.data | arrayOrStringIncludes("Vaccination")),
+              hint: {
+                text: "Date, vaccine details and dose given, site of body, legal mechanism and comments"
+              }
+            }
+          ]
+        }) }}
 
-          {{ button({
-            "text": "Continue"
-          }) }}
-        </form>
+        {{ button({
+          "text": "Continue"
+        }) }}
+      </form>
 
 
     </div>


### PR DESCRIPTION
All checkboxes for the data should start off selected, and then users can un-select any data they don't need.

<img width="885" alt="Screenshot 2024-09-10 at 17 11 48" src="https://github.com/user-attachments/assets/3e84ab34-962e-42de-9ae6-2f7e75993785">

If all options are unselected, they'd get an error:

<img width="892" alt="Screenshot 2024-09-10 at 17 12 24" src="https://github.com/user-attachments/assets/f4de6b14-2d3f-47f4-a654-4aad9f9db504">
