### PR TITLE
Display organisation name and address in profile

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
   currentUserId: "12345",
+  currentOrganisationId: "R0A",
   vaccines: [],
   "users": [
     {
@@ -174,6 +175,38 @@ module.exports = {
   ],
   data: [
     "Patients", "Staff", "Site or delivery team", "Assessment and consent", "Vaccination"
+  ],
+  organisations: [
+    {
+      id: "FAC81",
+      name: "Hambro Pharmacy",
+      type: "Community pharmacy",
+      address: {
+        line1: "53A Hullbridge Road",
+        town: "Rayleigh",
+        postcode: "SS6 9NL"
+      }
+    },
+    {
+      id: "FA464",
+      name: "Cohens Chemists",
+      type: "Community pharmacy",
+      address: {
+        line1: "151-151A Accrington Road",
+        town: "Burnley",
+        postcode: "BB11 5AL"
+      }
+    },
+    {
+      id: "R0A",
+      name: "Manchester University NHS Foundation Trust",
+      type: "NHS Trust",
+      address: {
+        line1: "Cobbett House, Oxford Road",
+        town: "Manchester",
+        postcode: "M13 9WL"
+      }
+    }
   ],
   "nhsTrusts": {
     "R0A": "Manchester University NHS Foundation Trust",

--- a/app/locals.js
+++ b/app/locals.js
@@ -1,8 +1,12 @@
 module.exports = (config) => (req, res, next) => {
   res.locals.serviceName = config.serviceName;
 
-  // Set currentUser for convenience
+  // Set currentUser and currentOrganisation for convenience
   res.locals.currentUser = req.session.data.users.find((user) => user.id === req.session.data.currentUserId);
+
+  // Set currentUser for convenience
+  res.locals.currentOrganisation = req.session.data.organisations.find((organisation) => organisation.id === req.session.data.currentOrganisationId);
+
 
   next();
 };

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -1,10 +1,21 @@
 module.exports = router => {
 
+  router.get('/select-organisation', (req, res) => {
+
+    const organisations = req.session.data.organisations.filter((organisation) =>  ["FAC81", "FA464"].includes(organisation.id))
+
+    res.render('select-organisation', {
+      organisations
+    })
+
+  })
+
   router.post('/select-organisation', (req, res) => {
     const organisationId = req.session.data.organisationId
 
     if (organisationId) {
       req.session.data.currentUserId = "12345";
+      req.session.data.currentOrganisationId = organisationId;
 
       // Reset data
       delete req.session.data.organisationId
@@ -18,8 +29,11 @@ module.exports = router => {
         href: "#organisationId-1"
       }
 
+      const organisations = req.session.data.organisations.filter((organisation) =>  ["FAC81", "FA464"].includes(organisation.id))
+
       res.render('select-organisation', {
-        error
+        error,
+        organisations
       })
     }
   })

--- a/app/views/select-organisation.html
+++ b/app/views/select-organisation.html
@@ -21,6 +21,20 @@
 
     <form action="/select-organisation" method="post">
 
+      {% set items = [] %}
+      {% for organisation in organisations %}
+
+        {% set items = (items.push({
+          value: organisation.id,
+          text: organisation.name,
+          hint: {
+            text: organisation.address.line1
+          }
+        }), items) %}
+      {% endfor %}
+
+
+
       {{ radios({
         name: "organisationId",
         fieldset: {
@@ -33,22 +47,7 @@
         errorMessage: {
           text: error.text
         } if error,
-        items: [
-          {
-            value: "FA424",
-            text: "Pickfords Pharmacy",
-            hint: {
-              text: "8 Spencer Court, Corby, NN17 1NU"
-            }
-          },
-          {
-            value: "FAH83",
-            text: "Claygate Pharmacy",
-            hint: {
-              text: "35 The Parade, Claygate, Esher, KT10 0PD"
-            }
-          }
-        ]
+        items: items
       }) }}
 
       {{ button({

--- a/app/views/user-profile/v2/index.html
+++ b/app/views/user-profile/v2/index.html
@@ -24,6 +24,14 @@
           </p>
         {% endset %}
 
+        {% set organisationHtml %}
+          <div>{{ currentOrganisation.name }}</div>
+          <p class="app-summary__explanation">
+            {{ currentOrganisation.address.line1 }}, {{ currentOrganisation.address.postcode }}
+          </p>
+
+        {% endset %}
+
         {{ summaryList({
           classes: "nhsuk-u-margin-bottom-4",
           rows: [
@@ -61,7 +69,7 @@
                 text: "Organisation"
               },
               value: {
-                text: currentOrganisation.name
+                html: organisationHtml
               },
               actions: {
                 items: [

--- a/app/views/user-profile/v2/index.html
+++ b/app/views/user-profile/v2/index.html
@@ -58,6 +58,20 @@
             },
             {
               key: {
+                text: "Organisation"
+              },
+              value: {
+                text: currentOrganisation.name
+              },
+              actions: {
+                items: [
+                  {
+                  }
+                ]
+              }
+            },
+            {
+              key: {
                 text: "Permission level"
               },
               value: {


### PR DESCRIPTION
This updates the profile page to show the user the name and address of the organisation they are signed in as.

This is mainly for the benefit of any users who may have multiple accounts with different organisations.

The address is shown as well as the organisation name, as some organisations have identical names, particularly community pharmacies (where there are hundreds with the name "Boots" or "Superdrug").

### Screenshot

<img width="1032" alt="Screenshot 2024-09-12 at 16 49 27" src="https://github.com/user-attachments/assets/f72b9ce5-2273-4290-9f06-ba32ecc2c74a">
