### PR TITLE
Update nhsuk frontend to version 9

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ app.use(cookieParser());
 const appViews = [
   path.join(__dirname, 'app/views/'),
   path.join(__dirname, 'node_modules/nhsuk-frontend/packages/components'),
+  path.join(__dirname, 'node_modules/nhsuk-frontend/packages/macros'),
   path.join(__dirname, 'docs/views/'),
   path.join(__dirname, 'lib/prototype-admin/'),
 ];

--- a/app.js
+++ b/app.js
@@ -180,6 +180,7 @@ if (useDocumentation || onlyDocumentation === 'true') {
   const docViews = [
     path.join(__dirname, 'docs/views/'),
     path.join(__dirname, 'node_modules/nhsuk-frontend/packages/components'),
+    path.join(__dirname, 'node_modules/nhsuk-frontend/packages/macros'),
   ];
 
   nunjucksAppEnv = nunjucks.configure(docViews, {

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -15,14 +15,9 @@
   NHS Record a vaccination prototypes
 {% endblock %}
 
-<!-- For adding a breadcrumb -->
-<!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/breadcrumbs -->
+<!-- For adding a breadcrumb or back link -->
+-->
 {% block beforeContent %}
-{% endblock %}
-
-<!-- For adding a back link -->
-<!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/back-link -->
-{% block outerContent %}
 {% endblock %}
 
 

--- a/app/views/page-example.html
+++ b/app/views/page-example.html
@@ -11,7 +11,7 @@
   Content page example - NHS.UK prototype kit
 {% endblock %}
 
-<!-- For adding a breadcrumb -->
+<!-- For adding a breadcrumb or back link -->
 <!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/breadcrumbs -->
 {% block beforeContent %}
   {{ breadcrumb({
@@ -21,7 +21,6 @@
 {% endblock %}
 
 <!-- For adding a back link -->
-<!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/back-link -->
 {% block outerContent %}
 {% endblock %}
 

--- a/app/views/page-example.html
+++ b/app/views/page-example.html
@@ -20,9 +20,6 @@
   }) }}
 {% endblock %}
 
-<!-- For adding a back link -->
-{% block outerContent %}
-{% endblock %}
 
 <!-- For adding page content -->
 <!-- Page layout code can be found at https://service-manual.nhs.uk/design-system/styles/layout -->

--- a/app/views/regions/v1/add-another-email-check.html
+++ b/app/views/regions/v1/add-another-email-check.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/organisations/" + organisation.code + "/add-email",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/add-another-email.html
+++ b/app/views/regions/v1/add-another-email.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/organisations/" + organisation.code,
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/add-email.html
+++ b/app/views/regions/v1/add-email.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/organisation-details",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/add-organisation.html
+++ b/app/views/regions/v1/add-organisation.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/check-and-send.html
+++ b/app/views/regions/v1/check-and-send.html
@@ -10,11 +10,10 @@
 
 {% set organisation = {name: organisation.name } %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/add-email",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/organisation-details.html
+++ b/app/views/regions/v1/organisation-details.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/add-organisation",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/organisation.html
+++ b/app/views/regions/v1/organisation.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1",
-    text: "Back to all organisations",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back to all organisations"
   }) }}
 {% endblock %}
 

--- a/app/views/regions/v1/uninvite.html
+++ b/app/views/regions/v1/uninvite.html
@@ -8,11 +8,10 @@
   {% include "includes/header-logged-in-region.html" %}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/regions/v1/organisations/" + organisation.code,
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -8,11 +8,10 @@
 
 {% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports/choose-data",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -7,11 +7,10 @@
 {% set currentSection = "reports" %}
 
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports/choose-site",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "reports" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "reports" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports/choose-vaccines",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -7,11 +7,10 @@
 {% set currentSection = "reports" %}
 
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports/choose-dates",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/reports/download.html
+++ b/app/views/reports/download.html
@@ -7,11 +7,10 @@
 {% set currentSection = "reports" %}
 
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/reports/check",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/support/region.html
+++ b/app/views/support/region.html
@@ -4,11 +4,10 @@
   {{ region.name }}
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/support",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "manage-users" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/change.html
+++ b/app/views/user-admin/change.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "manage-users" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/check.html
+++ b/app/views/user-admin/check.html
@@ -8,11 +8,10 @@
 
 {% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin/add-user",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/deactivate.html
+++ b/app/views/user-admin/deactivate.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "manage-users" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin/users/" + user.id + "/change-role",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/deactivated.html
+++ b/app/views/user-admin/deactivated.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "manage-users" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin",
-    text: "Back to Manage users",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back to Manage users"4"
   }) }}
 {% endblock %}
 

--- a/app/views/user-admin/reactivate.html
+++ b/app/views/user-admin/reactivate.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "manage-users" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-admin/deactivated",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-onboarding/v1/cis2-setup.html
+++ b/app/views/user-onboarding/v1/cis2-setup.html
@@ -4,11 +4,10 @@
   Manage users and permissions
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-onboarding/v1/setup",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-onboarding/v1/okta-setup.html
+++ b/app/views/user-onboarding/v1/okta-setup.html
@@ -4,11 +4,10 @@
   Manage users and permissions
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/user-onboarding/v1/cis2-alternative",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/user-profile/v1/email.html
+++ b/app/views/user-profile/v1/email.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "user-profile" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     text: "Back",
-    href: "/user-profile/v1",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    href: "/user-profile/v1"
 
   }) }}
 {% endblock %}

--- a/app/views/user-profile/v1/name.html
+++ b/app/views/user-profile/v1/name.html
@@ -7,11 +7,10 @@
 {% set currentSection = "user-profile" %}
 
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     text: "Back",
-    href: "/user-profile/v1",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    href: "/user-profile/v1"
 
   }) }}
 {% endblock %}

--- a/app/views/user-profile/v1/professional-body.html
+++ b/app/views/user-profile/v1/professional-body.html
@@ -7,11 +7,10 @@
 {% set currentSection = "user-profile" %}
 
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     text: "Back",
-    href: "/user-profile/v1",
-    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    href: "/user-profile/v1"
 
   }) }}
 {% endblock %}

--- a/app/views/user-profile/v2/name.html
+++ b/app/views/user-profile/v2/name.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "user-profile" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     text: "Back",
-    href: "/user-profile/v2",
-    classes: "nhsuk-u-margin-top-4"
+    href: "/user-profile/v2"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/add-batch-to-site-check.html
+++ b/app/views/vaccines/add-batch-to-site-check.html
@@ -7,11 +7,10 @@
 {% set currentSection = "vaccines" %}
 {% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/" + vaccine.id + "/add",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/add-batch-to-site.html
+++ b/app/views/vaccines/add-batch-to-site.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "vaccines" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/" + vaccine.id,
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "vaccines" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/choose-vaccine",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/choose-site.html
+++ b/app/views/vaccines/choose-site.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "vaccines" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/index",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/choose-vaccine.html
+++ b/app/views/vaccines/choose-vaccine.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "vaccines" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/choose-site",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/app/views/vaccines/product-page.html
+++ b/app/views/vaccines/product-page.html
@@ -6,11 +6,10 @@
 
 {% set currentSection = "vaccines" %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     href: "/vaccines/",
-    text: "Back",
-    classes: "nhsuk-u-margin-top-4"
+    text: "Back"
   }) }}
 {% endblock %}
 

--- a/docs/views/template.html
+++ b/docs/views/template.html
@@ -90,11 +90,9 @@
         {{ header({}) }}
       {% endblock %}
 
-      {% block beforeContent %}{% endblock %}
-
       {% block main %}
         <div class="nhsuk-width-container {{ containerClasses }}">
-          {% block outerContent %}{% endblock %}
+          {% block beforeContent %}{% endblock %}
           <main class="nhsuk-main-wrapper {{ mainClasses }}" id="maincontent" role="main">
             {% block content %}{% endblock %}
           </main>

--- a/docs/views/templates/blank-transactional.html
+++ b/docs/views/templates/blank-transactional.html
@@ -7,13 +7,9 @@
 {% endblock %}
 
 {% block beforeContent %}
-{% endblock %}
-
-{% block outerContent %}
   {{ backLink({
     "href": "/templates/start-page",
-    "text": "Back",
-    "classes": "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    "text": "Back"
   }) }}
 {% endblock %}
 

--- a/docs/views/templates/question-page.html
+++ b/docs/views/templates/question-page.html
@@ -6,11 +6,10 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "/templates/start-page",
-    "text": "Back",
-    "classes": "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    "text": "Back"
   }) }}
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "lodash": "^4.17.21",
-        "nhsuk-frontend": "^8.3.0",
+        "nhsuk-frontend": "^9.0.0",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "sass": "^1.77.8"
@@ -12062,9 +12062,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.3.0.tgz",
-      "integrity": "sha512-oln8/+0ZJwQgWPrEWcI7+4SeHdAfr3dkvZ5PAKswa6+66f7dbnwYq/IU+Aaqzp25EJsQuSlwElZghJHUKIUOqg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.0.0.tgz",
+      "integrity": "sha512-JZtrvbVqeThf8FC6Ky44zyXs0+sZHI2qCYDgTsuBcWFlASBerduCiYJ0NAL3Y4uHcsj4fe2I1Bc5zXidklDaDA==",
       "engines": {
         "node": ">=20.0.0"
       }
@@ -24698,9 +24698,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nhsuk-frontend": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.3.0.tgz",
-      "integrity": "sha512-oln8/+0ZJwQgWPrEWcI7+4SeHdAfr3dkvZ5PAKswa6+66f7dbnwYq/IU+Aaqzp25EJsQuSlwElZghJHUKIUOqg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.0.0.tgz",
+      "integrity": "sha512-JZtrvbVqeThf8FC6Ky44zyXs0+sZHI2qCYDgTsuBcWFlASBerduCiYJ0NAL3Y4uHcsj4fe2I1Bc5zXidklDaDA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "lodash": "^4.17.21",
-    "nhsuk-frontend": "^8.3.0",
+    "nhsuk-frontend": "^9.0.0",
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",
     "sass": "^1.77.8"


### PR DESCRIPTION
This updates the prototype to use [version 9.0.0 of NHSUK Frontend](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.0.0) and applies these breaking changes:

* add the `macros` path to the Nunjucks configuration so that the new `nhsukAttributes` helper macro is included
* merge `outerContent` and `beforeContent` blocks in the template to a single `beforeContent` block just before `<main>` but within `<div class="nhsuk-width-container">`
* updates all the back links to be within the `beforeContent` block instead of `outerContent`
* removes all the margin override classes from back links, as this is now applied by default

The heading sizes (eg `xl` and `l` and `m`) are unchanged, as this can be reviewed separately.