### PR TITLE
Update (and fix) date handling

### DIFF
--- a/app/routes/vaccines.js
+++ b/app/routes/vaccines.js
@@ -7,7 +7,7 @@ module.exports = (router) => {
 
     const generatedId = Math.floor(Math.random() * 10000000).toString()
 
-    const expiryDate = new Date(data['batchExpiryDate-year'], (data['batchExpiryDate-month'] - 1), data['batchExpiryDate-day'], 12).toISOString().substring(0,10)
+    const expiryDate = new Date(data.batchExpiryDate.year, (parseInt(data.batchExpiryDate.month) - 1), data.batchExpiryDate.day, 12).toISOString().substring(0,10)
 
     req.session.data.vaccines.push({
       id: generatedId,
@@ -28,9 +28,9 @@ module.exports = (router) => {
     req.session.data.vaccineProduct = ''
     req.session.data.siteCode = ''
     req.session.data.batchNumber = ''
-    req.session.data['batchExpiryDate-day'] = ''
-    req.session.data['batchExpiryDate-month'] = ''
-    req.session.data['batchExpiryDate-year'] = ''
+    req.session.data.batchExpiryDate.day = ''
+    req.session.data.batchExpiryDate.month = ''
+    req.session.data.batchExpiryDate.year = ''
 
     res.redirect('/vaccines/' + generatedId)
   })
@@ -68,7 +68,7 @@ module.exports = (router) => {
 
     const generatedId = Math.floor(Math.random() * 10000000).toString()
 
-    const expiryDate = new Date(data['batchExpiryDate-year'], (data['batchExpiryDate-month'] - 1), data['batchExpiryDate-day'], 12).toISOString().substring(0,10)
+    const expiryDate = new Date(data.batchExpiryDate.year, (parseInt(data.batchExpiryDate.month) - 1), data.batchExpiryDate.day, 12).toISOString().substring(0,10)
 
     vaccine.batches.push({
       id: generatedId,
@@ -78,9 +78,9 @@ module.exports = (router) => {
 
     // Reset data
     req.session.data.batchNumber = ''
-    req.session.data['batchExpiryDate-day'] = ''
-    req.session.data['batchExpiryDate-month'] = ''
-    req.session.data['batchExpiryDate-year'] = ''
+    req.session.data.batchExpiryDate.day = ''
+    req.session.data.batchExpiryDate.month = ''
+    req.session.data.batchExpiryDate.year = ''
 
     res.redirect('/vaccines/' + vaccine.id)
   })
@@ -160,7 +160,7 @@ module.exports = (router) => {
     const batch = vaccine.batches.find((batch) => batch.batchNumber === req.params.batchNumber)
     if (!batch) { res.redirect(`/vaccines/${vaccine.id}`); return }
 
-    const expiryDate = new Date(data['batchExpiryDate-year'], (data['batchExpiryDate-month'] - 1), data['batchExpiryDate-day']).toISOString().substring(0,10)
+    const expiryDate = new Date(data.batchExpiryDate.year, (parseInt(data.batchExpiryDate.month) - 1), data.batchExpiryDate.day, 12).toISOString().substring(0,10)
 
     batch.batchNumber = data.batchNumber;
     batch.expiryDate = expiryDate;

--- a/app/views/vaccines/add-batch-to-site-check.html
+++ b/app/views/vaccines/add-batch-to-site-check.html
@@ -89,7 +89,7 @@
               text: "Expiry date"
             },
             value: {
-              html: (data | isoDateFromDateInput("batchExpiryDate") | govukDate )
+              html: (data.batchExpiryDate | isoDateFromDateInput | govukDate )
             }
           }
         ]

--- a/app/views/vaccines/add-batch-to-site.html
+++ b/app/views/vaccines/add-batch-to-site.html
@@ -45,23 +45,7 @@
               "classes": "nhsuk-label--s"
             }
           },
-          "items": [
-            {
-              "name": "day",
-              "classes": "nhsuk-input--width-2",
-              value: data["batchExpiryDate-day"]
-            },
-            {
-              "name": "month",
-              "classes": "nhsuk-input--width-2",
-              value: data["batchExpiryDate-month"]
-            },
-            {
-              "name": "year",
-              "classes": "nhsuk-input--width-4",
-              value: data["batchExpiryDate-year"]
-            }
-          ]
+          values: data.batchExpiryDate
         }) }}
 
           {{ button({

--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -45,23 +45,7 @@
               "classes": "nhsuk-label--s"
             }
           },
-          "items": [
-            {
-              "name": "day",
-              "classes": "nhsuk-input--width-2",
-              value: data["batchExpiryDate-day"]
-            },
-            {
-              "name": "month",
-              "classes": "nhsuk-input--width-2",
-              value: data["batchExpiryDate-month"]
-            },
-            {
-              "name": "year",
-              "classes": "nhsuk-input--width-4",
-              value: data["batchExpiryDate-year"]
-            }
-          ]
+          values: data.batchExpiryDate
         }) }}
 
           {{ button({

--- a/app/views/vaccines/check.html
+++ b/app/views/vaccines/check.html
@@ -87,7 +87,7 @@
               text: "Expiry date"
             },
             value: {
-              html: (data | isoDateFromDateInput("batchExpiryDate") | govukDate )
+              html: (data.batchExpiryDate | isoDateFromDateInput | govukDate )
             }
           }
         ]

--- a/app/views/vaccines/edit-batch.html
+++ b/app/views/vaccines/edit-batch.html
@@ -35,23 +35,11 @@
               "classes": "nhsuk-label--s"
             }
           },
-          "items": [
-            {
-              "name": "day",
-              "classes": "nhsuk-input--width-2",
-              value: day
-            },
-            {
-              "name": "month",
-              "classes": "nhsuk-input--width-2",
-              value: month
-            },
-            {
-              "name": "year",
-              "classes": "nhsuk-input--width-4",
-              value: year
-            }
-          ]
+          values: {
+            day: day,
+            month: month,
+            year: year
+          }
         }) }}
 
         {{ button({


### PR DESCRIPTION
Since the update to version 9 of NHS Frontend, dates are now easier to retrieve and set.

This means that the `items` array no longer needs to be set on the date inputs, and instead a `values` object can be set at the top level.

When retrieving date parts, these can now be accessed using `data.batchExpiryDate.year` instead of `data['batchExpiryDate-year']`.

When using the [`isoDateFromDateInput` filter](https://x-govuk.github.io/govuk-prototype-filters/date/#isodatefromdateinput), this no longer needs to be given the prefix, and can instead be passed the whole date object.

Before:

```njk
{{ data | isoDateFromDateInput("batchExpiryDate") | govukDate }}
```

After

```njk
{{ data.batchExpiryDate | isoDateFromDateInput | govukDate }}
```