### PR TITLE
Tweak filter on vaccines page

### DIFF
--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -61,7 +61,7 @@
       {% for site in sites %}
 
         <table class="nhsuk-table">
-          <caption class="nhsuk-table__caption nhsuk-table__caption--m">{{ data.sites[site].name }}</caption>
+          <caption class="nhsuk-table__caption nhsuk-table__caption--m nhsuk-u-margin-bottom-2">{{ data.sites[site].name }}</caption>
           <thead role="rowgroup" class="nhsuk-table__head">
             <tr role="row">
               <th role="columnheader" class="" scope="col">

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -6,6 +6,13 @@
 
 {% set currentSection = "vaccines" %}
 
+{% set sites = [] %}
+{% for vaccine in (data.vaccines) %}
+  {% if not (sites | arrayOrStringIncludes(vaccine.siteCode)) %}
+    {% set sites = (sites.push(vaccine.siteCode), sites) %}
+  {% endif %}
+{% endfor %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -24,40 +31,30 @@
 
   {% from 'select/macro.njk' import select %}
 
-  {{ select({
-    id: "select-1",
-    name: "select-1",
-    label: {
-      text: "Select site"
-    },
-    items: [
-      {
-        value: 1,
-        text: "NHS.UK frontend option 1"
+  {% if (sites | length) > 1 %}
+    {% set filterItems = [{
+      text: "All",
+      value: "",
+      selected: true
+    }] %}
+
+    {% for site in sites %}
+      {% set filterItems = (filterItems.push({text: data.sites[site].name, value: site}), filterItems) %}
+    {% endfor %}
+
+    {{ select({
+      id: "select-1",
+      name: "select-1",
+      label: {
+        text: "Show"
       },
-      {
-        value: 2,
-        text: "NHS.UK frontend option 2",
-        selected: true
-      },
-      {
-        value: 3,
-        text: "NHS.UK frontend option 3",
-        disabled: true
-      }
-    ]
-  }) }}
+      items: filterItems
+    }) }}
+  {% endif %}
 
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-
-      {% set sites = [] %}
-      {% for vaccine in (data.vaccines) %}
-        {% if not (sites | arrayOrStringIncludes(vaccine.siteCode)) %}
-          {% set sites = (sites.push(vaccine.siteCode), sites) %}
-        {% endif %}
-      {% endfor %}
 
       {% for site in sites %}
 

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -15,7 +15,7 @@
 
 {% block content %}
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
+    <div class="nhsuk-grid-column-two-thirds nhsuk-u-margin-bottom-5">
 
       <h1 class="nhsuk-heading-xl">Vaccines</h1>
 

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -33,7 +33,7 @@
 
   {% if (sites | length) > 4 %}
     {% set filterItems = [{
-      text: "All",
+      text: "All sites",
       value: "",
       selected: true
     }] %}

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -31,7 +31,7 @@
 
   {% from 'select/macro.njk' import select %}
 
-  {% if (sites | length) > 1 %}
+  {% if (sites | length) > 4 %}
     {% set filterItems = [{
       text: "All",
       value: "",
@@ -42,14 +42,16 @@
       {% set filterItems = (filterItems.push({text: data.sites[site].name, value: site}), filterItems) %}
     {% endfor %}
 
-    {{ select({
-      id: "select-1",
-      name: "select-1",
-      label: {
-        text: "Show"
-      },
-      items: filterItems
-    }) }}
+
+      {{ select({
+        label: {
+          text: "Show"
+        },
+        id: "select-1",
+        name: "select-1",
+        items: filterItems,
+        classes: "nhsuk-u-margin-bottom-3"
+      }) }}
   {% endif %}
 
 

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -58,9 +58,8 @@
 
       {% for site in sites %}
 
-        <h2 class="nhsuk-heading-m">{{ data.sites[site].name }}</h2>
-
         <table class="nhsuk-table">
+          <caption class="nhsuk-table__caption nhsuk-table__caption--m">{{ data.sites[site].name }}</caption>
           <thead role="rowgroup" class="nhsuk-table__head">
             <tr role="row">
               <th role="columnheader" class="" scope="col">


### PR DESCRIPTION
This tweaks site "sites" filter on the Vaccines page, so that:

* the label changes from 'Site' to 'Show'
* the default 'Please select' changes to 'All site'
* it only shows if there are more than 4 sites added
* there's a bit more spacing around it

(Note: the actual filter doesn't yet work in the prototype)

## Screenshots

| 4 sites | 5 sites |
| ------- | ------- |
| ![vaccines-4-sites](https://github.com/user-attachments/assets/237ea652-e4d6-4a59-bd05-563ca177878d) | ![vaccines-with-5-sites](https://github.com/user-attachments/assets/ed518b5b-4822-45cd-a0d5-cd65d5b12153) |


