### PR TITLE
Increase reports max date range to 31 days

### DIFF
--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -142,8 +142,8 @@ module.exports = (router) => {
         from = new Date(today.getTime() - (14 * days)).toISOString().substring(0,10)
         to = today.toISOString().substring(0,10)
         break
-      case 'Last30days':
-        from = new Date(today.getTime() - (14 * days)).toISOString().substring(0,10)
+      case 'Last31days':
+        from = new Date(today.getTime() - (31 * days)).toISOString().substring(0,10)
         to = today.toISOString().substring(0,10)
         break
     }

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -53,7 +53,7 @@
               }
             },
             hint: {
-              text: "For example, 1 6 2024"
+              text: "For example, 1 7 2024"
             },
             errorMessage: {
               text: dateFromError
@@ -89,7 +89,7 @@
                 }
               },
               hint: {
-                text: "For example, 30 6 2024"
+                text: "For example, 31 7 2024"
               },
               errorMessage: {
                 text: dateToError
@@ -165,19 +165,16 @@
               }
             },
             {
-                "value": "Last30days",
-                "text": "Last 30 days",
-                checked: (data.date == "Last30days"),
-                conditional: {
-                  html: Last30days
-                }
+                "value": "Last31days",
+                "text": "Last 31 days",
+                checked: (data.date == "Last31days")
               },
             {
               divider: "or"
             },
             {
               "value": "custom_date_range",
-              "text": "Select custom date range up to 30 days",
+              "text": "Select custom date range up to 31 days",
               checked: (data.date == "custom_date_range"),
               conditional: {
                 html: custom_date_range


### PR DESCRIPTION
It makes sense to go up to 31 days, so that users can download a full calendar month (for months with 31 days).

## Screenshots

| Before | After |
| -------| ----- |
| <img width="691" alt="Screenshot 2024-09-25 at 16 14 38" src="https://github.com/user-attachments/assets/f72f530a-a8d7-4107-9515-89b35f60735a"> | <img width="696" alt="Screenshot 2024-09-25 at 16 11 22" src="https://github.com/user-attachments/assets/a82c9a59-388a-4d3e-a588-eb04f345b19e"> |
