### PR TITLE
Update NHS Frontend to 9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "lodash": "^4.17.21",
-        "nhsuk-frontend": "^9.0.0",
+        "nhsuk-frontend": "^9.1.0",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "sass": "^1.77.8"
@@ -12096,9 +12096,10 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.0.0.tgz",
-      "integrity": "sha512-JZtrvbVqeThf8FC6Ky44zyXs0+sZHI2qCYDgTsuBcWFlASBerduCiYJ0NAL3Y4uHcsj4fe2I1Bc5zXidklDaDA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.1.0.tgz",
+      "integrity": "sha512-z2hcZDUDz12hjBTWLasq5lfX+sv2jwZFkUdip8qL9fBQ6qykyQFQ8PjWuBBgQN03IU0wMkV3BBLbwBjFiSxREQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       }
@@ -24752,9 +24753,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nhsuk-frontend": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.0.0.tgz",
-      "integrity": "sha512-JZtrvbVqeThf8FC6Ky44zyXs0+sZHI2qCYDgTsuBcWFlASBerduCiYJ0NAL3Y4uHcsj4fe2I1Bc5zXidklDaDA=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.1.0.tgz",
+      "integrity": "sha512-z2hcZDUDz12hjBTWLasq5lfX+sv2jwZFkUdip8qL9fBQ6qykyQFQ8PjWuBBgQN03IU0wMkV3BBLbwBjFiSxREQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "lodash": "^4.17.21",
-    "nhsuk-frontend": "^9.0.0",
+    "nhsuk-frontend": "^9.1.0",
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",
     "sass": "^1.77.8"


### PR DESCRIPTION
Main difference is a change in alignment in the header for the nav.


## Screenshots

### Before

<img width="982" alt="Screenshot 2024-11-05 at 14 48 04" src="https://github.com/user-attachments/assets/c97053c3-d54a-4d84-93d3-fe3e73a2dee7">

### After

<img width="994" alt="Screenshot 2024-11-05 at 14 47 30" src="https://github.com/user-attachments/assets/9b8ba392-28ae-47fe-b0a1-1b1b238330f0">
