### PR TITLE
Remove 'Since 1 Sep' figures

### DIFF
--- a/app/views/home/index.html
+++ b/app/views/home/index.html
@@ -52,7 +52,7 @@
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       {% set cardHtml %}
         <p class="nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1">546</p>
-        October so far
+        November so far
       {% endset %}
 
       {{ card({
@@ -60,17 +60,6 @@
       }) }}
     </li>
 
-
-    <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
-      {% set cardHtml %}
-        <p class="nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1"><span class="nhsuk-u-font-size-48">16,141</span></p>
-        Since 1 Sep 2024
-      {% endset %}
-
-      {{ card({
-        headingHtml: cardHtml
-      }) }}
-    </li>
 </ul>
 
 

--- a/app/views/home/site.html
+++ b/app/views/home/site.html
@@ -52,7 +52,7 @@
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       {% set cardHtml %}
         <p class="nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1">318</p>
-        October so far
+        November so far
       {% endset %}
 
       {{ card({
@@ -60,17 +60,6 @@
       }) }}
     </li>
 
-
-    <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
-      {% set cardHtml %}
-        <p class="nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1"><span class="nhsuk-u-font-size-48">9,812</span></p>
-        Since 1 Sep 2024
-      {% endset %}
-
-      {{ card({
-        headingHtml: cardHtml
-      }) }}
-    </li>
 </ul>
 
 


### PR DESCRIPTION
Removing these for now as we’re not sure they're needed or how it’d work with a Spring campaign.