### PR TITLE
Add errors and warnings based on estimated due date

### DIFF
--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -173,11 +173,11 @@ module.exports = router => {
     }
 
     // RSV is recommended from 28+ weeks (196 days)
-    if (data.vaccine === "RSV" && numberOfDaysPregnant < 196) {
+    if (data.vaccinationToday == 'yes' && data.vaccine === "RSV" && numberOfDaysPregnant < 196) {
       res.redirect('/vaccinate/patient-estimated-due-date-rsv-warning')
 
     // Pertussis is recommended between 16 weeks (112 days) and 32 weeks
-    } else if (data.vaccine === "Pertussis" && numberOfDaysPregnant < 112) {
+    } else if (data.vaccinationToday == 'yes' && data.vaccine === "Pertussis" && numberOfDaysPregnant < 112) {
       res.redirect('/vaccinate/patient-estimated-due-date-pertussis-warning')
     } else {
       res.redirect('/vaccinate/consent')

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -128,10 +128,8 @@ module.exports = router => {
         // Estimated due date is based on 40 weeks (280 days) since last period
         const numberOfDaysPregnant = 280 - daysBetweenDates(vaccinationDate, pregnancyDueDate)
 
-        if (numberOfDaysPregnant < 0) {
-          dateErrorMessage = "Estimated due date cannot be more than 40 weeks after vaccination date"
-        } else if (numberOfDaysPregnant < 28) {
-          dateErrorMessage = "Patient must be at least 28 days pregnant"
+        if (numberOfDaysPregnant < 21) {
+          dateErrorMessage = "Estimated due date is too far in the future. Patient must be at least 21 days pregnant."
         } else if (numberOfDaysPregnant > 308) {
           dateErrorMessage = "Patient cannot be more than 44 weeks pregnant"
         }
@@ -168,9 +166,9 @@ module.exports = router => {
     // Estimated due date is based on 40 weeks (280 days) since last period
     const numberOfDaysPregnant = 280 - daysBetweenDates(vaccinationDate, pregnancyDueDate)
 
-    // Being less than 4 weeks or more than 44 weeks (308 days) pregnant
+    // Being less than 3 weeks or more than 44 weeks (308 days) pregnant
     // results in an error
-    if (numberOfDaysPregnant < 28 || numberOfDaysPregnant > 308) {
+    if (numberOfDaysPregnant < 21 || numberOfDaysPregnant > 308) {
       return res.redirect('/vaccinate/patient-estimated-due-date?showError=yes')
     }
 

--- a/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
@@ -14,15 +14,14 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Are you sure you want to give the vaccine?</h1>
-
+      <h1 class="nhsuk-heading-l">Are you sure you want to continue?</h1>
 
       <p>{{ data.patientName }} is {{ fullWeeksPregnant | plural("week") }}{% if remainderDaysPregnant > 0 %} and {{ remainderDaysPregnant | plural("day") }}{% endif %} pregnant.
       </p>
 
       <p>The pertussis vaccine is recommended between 16 and 32 weeks of pregnancy.</p>
 
-      <p><a href="https://www.gov.uk/government/publications/vaccination-against-pertussis-whooping-cough-for-pregnant-women/pertussis-whooping-cough-vaccination-programme-for-pregnant-women" target="_blank">UKHSA guidance on Pertussis vaccination of pregnant women (opens in new tab)</a>.
+      <p><a href="https://www.gov.uk/government/publications/vaccination-against-pertussis-whooping-cough-for-pregnant-women/pertussis-whooping-cough-vaccination-programme-for-pregnant-women" target="_blank">UKHSA guidance on pertussis vaccination of pregnant women (opens in new tab)</a>.
 
 
     </div>

--- a/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
@@ -1,0 +1,37 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Vaccines
+{% endblock %}
+
+{% set currentSection = "vaccinate" %}
+
+{% block beforeContent %}
+  {{ backLink({ href: "/vaccinate/patient-estimated-due-date" }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Are you sure you want to give the vaccine?</h1>
+
+
+      <p>{{ data.patientName }} is {{ fullWeeksPregnant | plural("week") }}{% if remainderDaysPregnant > 0 %} and {{ remainderDaysPregnant | plural("day") }}{% endif %} pregnant.
+      </p>
+
+      <p>The Pertussis vaccine is not routinely recommended before 16 weeks of pregnancy.</p>
+
+      <p><a href="https://www.gov.uk/government/publications/vaccination-against-pertussis-whooping-cough-for-pregnant-women/pertussis-whooping-cough-vaccination-programme-for-pregnant-women" target="_blank">UKHSA guidance on Pertussis vaccination of pregnant women (opens in new tab)</a>.
+
+
+    </div>
+  </div>
+
+  {{ button({
+    "text": "Continue",
+    "href": "/vaccinate/consent"
+  }) }}
+
+{% endblock %}
+

--- a/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
@@ -20,7 +20,7 @@
       <p>{{ data.patientName }} is {{ fullWeeksPregnant | plural("week") }}{% if remainderDaysPregnant > 0 %} and {{ remainderDaysPregnant | plural("day") }}{% endif %} pregnant.
       </p>
 
-      <p>The Pertussis vaccine is not routinely recommended before 16 weeks of pregnancy.</p>
+      <p>The pertussis vaccine is recommended between 16 and 32 weeks of pregnancy.</p>
 
       <p><a href="https://www.gov.uk/government/publications/vaccination-against-pertussis-whooping-cough-for-pregnant-women/pertussis-whooping-cough-vaccination-programme-for-pregnant-women" target="_blank">UKHSA guidance on Pertussis vaccination of pregnant women (opens in new tab)</a>.
 

--- a/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
@@ -14,7 +14,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Are you sure you want to give the vaccine?</h1>
+      <h1 class="nhsuk-heading-l">Are you sure you want to continue?</h1>
 
 
       <p>{{ data.patientName }} is {{ fullWeeksPregnant | plural("week") }}{% if remainderDaysPregnant > 0 %} and {{ remainderDaysPregnant | plural("day") }}{% endif %} pregnant.

--- a/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
@@ -1,0 +1,37 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Vaccines
+{% endblock %}
+
+{% set currentSection = "vaccinate" %}
+
+{% block beforeContent %}
+  {{ backLink({ href: "/vaccinate/patient-estimated-due-date" }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Are you sure you want to give the vaccine?</h1>
+
+
+      <p>{{ data.patientName }} is {{ fullWeeksPregnant | plural("week") }}{% if remainderDaysPregnant > 0 %} and {{ remainderDaysPregnant | plural("day") }}{% endif %} pregnant.
+      </p>
+
+      <p>The {{ data.vaccine }} vaccine is not routinely recommended before 28 weeks of pregnancy.</p>
+
+      <p><a href="https://www.gov.uk/government/publications/respiratory-syncytial-virus-rsv-programme-information-for-healthcare-professionals/rsv-vaccination-of-pregnant-women-for-infant-protection-information-for-healthcare-practitioners" target="_blank">UKHSA guidance on RSV vaccination of pregnant women (opens in new tab)</a>.
+
+
+    </div>
+  </div>
+
+  {{ button({
+    "text": "Continue",
+    "href": "/vaccinate/consent"
+  }) }}
+
+{% endblock %}
+

--- a/app/views/vaccinate/patient-estimated-due-date.html
+++ b/app/views/vaccinate/patient-estimated-due-date.html
@@ -14,7 +14,20 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form action="/vaccinate/consent" method="post" novalidate>
+      {% if dateErrorMessage %}
+        {{ errorSummary({
+          titleText: "There is a problem",
+          errorList: [{
+            text: dateErrorMessage,
+            href: "#pregnancyDueDate-day"
+          }]
+        }) }}
+      {% endif %}
+
+
+      <form action="/vaccinate/save-estimated-due-date" method="post" novalidate>
+        <!-- reset showError to false -->
+        <input type="hidden" name="showError" value="">
 
         {{ dateInput({
           id: "pregnancyDueDate",
@@ -26,6 +39,9 @@
               isPageHeading: true
             }
           },
+          errorMessage: {
+            text: dateErrorMessage
+          } if dateErrorMessage,
           values: data.pregnancyDueDate,
           hint: {
             text: "For example, 15 6 2025"
@@ -33,15 +49,15 @@
           items: [
             {
               name: "day",
-              classes: "nhsuk-input--width-2"
+              classes: "nhsuk-input--width-2 " + ("nhsuk-input--error" if dateErrorMessage else "")
             },
             {
               name: "month",
-              classes: "nhsuk-input--width-2"
+              classes: "nhsuk-input--width-2 " + ("nhsuk-input--error" if dateErrorMessage else "")
             },
             {
               name: "year",
-              classes: "nhsuk-input--width-4"
+              classes: "nhsuk-input--width-4 " + ("nhsuk-input--error" if dateErrorMessage else "")
             }
           ]
         }) }}


### PR DESCRIPTION
This adds some error messages if the estimated due date is highly likely to be an error, and some warnings if the estimated due date is outside the recommended period, but still possible.

## Errors

### Blank

<img width="812" alt="Screenshot 2025-01-14 at 15 02 12" src="https://github.com/user-attachments/assets/9afe8356-536a-4713-96fe-052e8d2f271c" />

### Due date is more than 37 weeks after vaccination date

This is an error as also highly unlikely to know they are pregnant at this point

![Screenshot 2025-01-16 at 14 18 36](https://github.com/user-attachments/assets/558dc3f2-ed70-4301-a66c-ef8dadb570d8)

### Due date is more than 4 weeks before vaccination date

This is an error as almost no pregnancies will go beyond 44 weeks

<img width="908" alt="Screenshot 2025-01-14 at 14 58 25" src="https://github.com/user-attachments/assets/868d0ffd-f4d1-4315-a589-aec5c3aca4c8" />

## Warnings

These are shown on a subsequent page, and users can choose to either continue, go back (eg to fix a mistake) or cancel the vaccination (by navigating away).

### RSV

This is only shown if the patient is not yet 28 weeks pregnant

![Screenshot 2025-01-16 at 14 22 29](https://github.com/user-attachments/assets/02398ba6-611b-4e73-bbd2-be5b9f585094)

### Pertussis

This is only shown if the patient is not yet 16 weeks pregnant

![Screenshot 2025-01-16 at 14 21 30](https://github.com/user-attachments/assets/38445572-e68b-409f-ac1a-a11e114f90b5)

 