### PR TITLE
Allow users to add a batch as part of the flow

### DIFF
--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -83,14 +83,25 @@ module.exports = router => {
   // Routing page after DONE
   router.post('/vaccinate/what-next', (req, res) => {
 
-    const answer = req.session.data.nextStep;
+    const data = req.session.data
+    const answer = data.nextStep
 
-    req.session.data.injectionSite = ""
+    // Reset these value regardless of next step
+    data.injectionSite = ""
+    data.consent = ""
+    data.consentName = ""
 
     if (answer === 'same-vaccination-another-patient') {
 
       req.session.data.patientName = ""
       req.session.data.nhsNumber = ""
+
+      // newly added batch becomes the default
+      if (data.vaccineBatch == 'add-new') {
+        data.vaccineBatch = data.newBatchNumber
+        data.vaccineExpiryDate = data.newBatchExpiryDate
+        data.newBatchNumber = ""
+      }
 
       res.redirect('/vaccinate/patient?repeatVaccination=yes&repeatPatient=no')
 
@@ -109,25 +120,24 @@ module.exports = router => {
 
   })
 
+  router.post('/vaccinate/answer-batch', (req, res) => {
 
+    const data = req.session.data
+    const vaccineBatch = data.vaccineBatch
+    const vaccine = data.vaccine
 
-  router.post('/vaccinate/answer-patient-nhs-number-known', (req, res) => {
+    let redirectPath
 
-    const nhsNumberKnown = req.session.data.nhsNumberKnown;
-
-    if (nhsNumberKnown === "yes") {
-
-      req.session.data.patientName = "Jodie Brown"
-      req.session.data.dateOfBirth = {day: "4", month: "7", year: "1964"}
-      req.session.data.postcode = "GD3 I83"
-
-      res.redirect('/vaccinate/patient-history')
-    } else if (nhsNumberKnown === "no") {
-      res.redirect('/vaccinate/patient-search')
+    if (vaccineBatch === "add-new") {
+      redirectPath = "/vaccinate/add-batch"
+    } else if (vaccine === "Pertussis") {
+      redirectPath = "/vaccinate/patient"
+    } else if (vaccine === "RSV") {
+      redirectPath = "/vaccinate/eligibility"
     } else {
-      res.redirect('/vaccinate/patient?showError=yes')
+      redirectPath = "/vaccinate/location"
     }
-
+    res.redirect(redirectPath)
   })
 
 

--- a/app/views/vaccinate/add-batch.html
+++ b/app/views/vaccinate/add-batch.html
@@ -17,35 +17,43 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuks-heading-xl">Add batch</h1>
+      <h1 class="nhsuks-heading-l">Add batch</h1>
 
-      <form action="/vaccinate/eligibility" method="post" novalidate="true">
+      {% if data.vaccine == "Pertussis" %}
+        {% set nextPage = "/vaccinate/patient" %}
+      {% elseif data.vaccine == "RSV" %}
+        {% set nextPage = "/vaccinate/eligibility" %}
+      {% else %}
+        {% set nextPage = "/vaccinate/location" %}
+      {% endif %}
+
+      <form action="{{ nextPage }}" method="post" novalidate>
 
         {{ input({
           "label": {
-            "text": "Batch number",
+            "text": data.vaccine + " batch number",
             classes: "nhsuk-label--s"
           },
           hint: {
             text: "For example, XX123456"
           },
           "id": "batch-number",
-          "name": "batchNumber",
+          "name": "newBatchNumber",
           classes: "nhsuk-input--width-20",
-          value: data.batchNumber
+          value: data.newBatchNumber
         }) }}
 
 
         {{ dateInput({
-          "id": "batchExpiryDate",
-          "namePrefix": "batchExpiryDate",
+          "id": "newBatchExpiryDate",
+          "namePrefix": "newBatchExpiryDate",
           "fieldset": {
             "legend": {
               "text": "Expiry date",
               "classes": "nhsuk-label--s"
             }
           },
-          values: data.batchExpiryDate
+          values: data.newBatchExpiryDate
         }) }}
 
           {{ button({

--- a/app/views/vaccinate/batch.html
+++ b/app/views/vaccinate/batch.html
@@ -14,15 +14,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {% if data.vaccine == "Pertussis" %}
-        {% set nextPage = "/vaccinate/patient" %}
-      {% elseif data.vaccine == "RSV" %}
-        {% set nextPage = "/vaccinate/eligibility" %}
-      {% else %}
-        {% set nextPage = "/vaccinate/location" %}
-      {% endif %}
-
-      <form action="{{ nextPage }}" method="post" novalidate>
+      <form action="/vaccinate/answer-batch" method="post" novalidate>
 
           {{ radios({
             "idPrefix": "vaccineBatch",
@@ -72,7 +64,8 @@
               },
               {
                 "value": "add-new",
-                "text": "Add a batch"
+                "text": "Add a batch",
+                checked: (data.vaccineBatch == "add-new")
               }
             ]
           }) }}

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -18,6 +18,17 @@
   {% endif %}
 {% endset %}
 
+{% set batchHtml %}
+  {% if data.vaccineBatch == "add-new" %}
+    {{ data.newBatchNumber }}
+    <br>Expires {{ (data.newBatchExpiryDate | isoDateFromDateInput | govukDate)  }}
+  {% else %}
+    {{ data.vaccineBatch }}
+    <br>Expires 4 January 2025
+  {% endif %}
+
+{% endset %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -149,12 +160,12 @@
               text: "Batch"
             },
             value: {
-              html: data.vaccineBatch + "<br>Expires 4 January 2025"
+              html: batchHtml
             },
             actions: {
               items: [
                 {
-                  href: "/vaccinate/batch",
+                  href: ("/vaccinate/add-batch" if data.vaccineBatch == "add-new" else "/vaccinate/batch"),
                   text: "Change",
                   visuallyHiddenText: "vaccine batch"
                 }


### PR DESCRIPTION
This lets users add a vaccine batch as part of the 'Record vaccination' flow.

Only users with 'admin' or 'lead admin' permission would be able to do this - others would not see the 'Add a batch' option.

## Screenshots

### Selecting 'Add a new batch'

![Screenshot 2025-01-16 at 16 43 11](https://github.com/user-attachments/assets/cc184089-16a4-4150-9fe1-7ad2f9133d6a)

### Adding details of the new batch

![Screenshot 2025-01-16 at 16 43 56](https://github.com/user-attachments/assets/13e863d4-efa6-49f8-a55b-9c3e40e3f8a4)
