### PR TITLE
Update patient-history.html with extra covid record

### DIFF
--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -107,6 +107,16 @@
           rows: [
             [
               {
+                text: "1 December 2024"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Spikevax JN.1"
+              }
+            ],[
+              {
                 text: "11 November 2024"
               },
               {


### PR DESCRIPTION
Ahead of user testing, added a COVID-19 record for 1 December 2024 to vax history - to help make sense of the warning msg that appears if you had a COVID-19 vax less than 3 months ago.