### PR TITLE
Update vax history explanation on patient-history.html

### DIFF
--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -81,9 +81,9 @@
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
 
-      <p>This is not a complete vaccination history. It only includes records of COVID-19, flu, pertussis and RSV vaccinations given on the NHS.</p>
+      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, pertussis and RSV vaccinations.</p>
 
-      <p>Note that if an RSV or pertussis vaccination was given at a GP practice, the record will not appear here.</p>
+      <p>However, if an RSV or pertussis vaccination was given at a GP practice, it will not show here.</p>
     </div>
   </div>
   <div class="nhsuk-grid-row">


### PR DESCRIPTION
Changed the text explaining what the history show from: 'This is not a complete vaccination history. It only includes records of COVID-19, flu, pertussis and RSV vaccinations given on the NHS. Note that if an RSV or pertussis vaccination was given at a GP practice, the record will not appear here.' To:
'This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, pertussis and RSV vaccinations. However, if a pertussis or RSV vaccination was given at a GP practice, it will not show here.'