### PR TITLE
Add consent error messages and tweak Check your answers page

### DIFF
--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -551,7 +551,7 @@ module.exports = router => {
           href: "#consent-1"
         }
         errors.push(consentError)
-      } else if (consent === "Clinician following the Mental Capacity Act" && consentClinicianName === '') {
+      } else if (consent === "Clinician acting in the patient’s best interests" && consentClinicianName === '') {
 
         consentClinicianError = {
           text: "Enter a name",
@@ -605,7 +605,7 @@ module.exports = router => {
 
     if (
       (consent === "patient") ||
-      (consent === "Clinician following the Mental Capacity Act" && consentClinicianName != '') ||
+      (consent === "Clinician acting in the patient’s best interests" && consentClinicianName != '') ||
       (consent === "Person with power of attorney for personal welfare" && consentAttorneyName != '') ||
       (consent === "Parent or guardian" && consentParentName != '') ||
       (consent === "Mental capacity advocate" && consentAdvocateName != '') ||

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -487,8 +487,6 @@ module.exports = router => {
     const consentAdvocateName = data.consentAdvocateName
     const consentDeputyName = data.consentDeputyName
 
-    console.log(consent)
-
     if (req.query.showErrors === 'yes') {
       if (!consent) {
         consentError = {

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -400,7 +400,11 @@ module.exports = router => {
     data.injectionSite = ""
     data.otherInjectionSite = ""
     data.consent = ""
-    data.consentName = ""
+    data.consentClinicianName = ""
+    data.consentAttorneyName = ""
+    data.consentParentName = ""
+    data.consentAdvocateName = ""
+    data.consentDeputyName = ""
 
     if (answer === 'same-vaccination-another-patient') {
 
@@ -472,5 +476,91 @@ module.exports = router => {
     res.redirect(redirectPath)
   })
 
+  router.get('/vaccinate/consent', (req, res) => {
+    let errors = []
+    let consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError
+    const data = req.session.data
+    const consent = data.consent
+    const consentClinicianName = data.consentClinicianName
+    const consentAttorneyName = data.consentAttorneyName
+    const consentParentName = data.consentParentName
+    const consentAdvocateName = data.consentAdvocateName
+    const consentDeputyName = data.consentDeputyName
+
+    console.log(consent)
+
+    if (req.query.showErrors === 'yes') {
+      if (!consent) {
+        consentError = {
+          text: "Select who gave consent",
+          href: "#consent-1"
+        }
+        errors.push(consentError)
+      } else if (consent === "Clinician following the Mental Capacity Act" && consentClinicianName === '') {
+
+        consentClinicianError = {
+          text: "Enter a name",
+          href: "#consent-clinician-name"
+        }
+        errors.push(consentClinicianError)
+      } else if (consent === "Person with power of attorney for personal welfare" && consentAttorneyName === '') {
+
+        consentAttorneyError = {
+          text: "Enter a name",
+          href: "#consent-attorney-name"
+        }
+        errors.push(consentAttorneyError)
+      } else if (consent === "Parent or guardian" && consentParentName === '') {
+
+        consentParentError = {
+          text: "Enter a name",
+          href: "#consent-parent-name"
+        }
+        errors.push(consentParentError)
+      } else if (consent === "Mental capacity advocate" && consentAdvocateName === '') {
+
+        consentAdvocateError = {
+          text: "Enter a name",
+          href: "#consent-advocate-name"
+        }
+        errors.push(consentAdvocateError)
+      } else if (consent === "Court appointed deputy" && consentDeputyName === '') {
+
+        consentDeputyError = {
+          text: "Enter a name",
+          href: "#consent-deputy-name"
+        }
+        errors.push(consentDeputyError)
+      }
+    }
+
+    res.render('vaccinate/consent', {
+      errors, consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError
+    })
+  })
+
+  router.post('/vaccinate/answer-consent', (req, res) => {
+    const data = req.session.data
+    const consent = data.consent
+    const consentClinicianName = data.consentClinicianName
+    const consentAttorneyName = data.consentAttorneyName
+    const consentParentName = data.consentParentName
+    const consentAdvocateName = data.consentAdvocateName
+    const consentDeputyName = data.consentDeputyName
+
+    if (
+      (consent === "patient") ||
+      (consent === "Clinician following the Mental Capacity Act" && consentClinicianName != '') ||
+      (consent === "Person with power of attorney for personal welfare" && consentAttorneyName != '') ||
+      (consent === "Parent or guardian" && consentParentName != '') ||
+      (consent === "Mental capacity advocate" && consentAdvocateName != '') ||
+      (consent === "Court appointed deputy" && consentDeputyName != '')
+    ) {
+      res.redirect('/vaccinate/injection-site')
+    } else {
+      res.redirect('/vaccinate/consent?showErrors=yes')
+    }
+
+  })
 
 }

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -15,7 +15,7 @@
     Patient
   {% elseif data.consent == "Clinician following the Mental Capacity Act" %}
     {{ data.consentClinicianName }}
-    <br>Clinician
+    <br>Clinician (best interests)
   {% elseif data.consent == "Person with power of attorney for personal welfare" %}
     {{ data.consentAttorneyName }}
     <br>Power of attorney

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -13,9 +13,9 @@
 {% set consentHtml %}
   {% if data.consent == "patient" %}
     Patient
-  {% elseif data.consent == "Clinician following the Mental Capacity Act" %}
+  {% elseif data.consent == "Clinician acting in the patient’s best interests" %}
     {{ data.consentClinicianName }}
-    <br>Clinician (best interests)
+    <br>Clinician
   {% elseif data.consent == "Person with power of attorney for personal welfare" %}
     {{ data.consentAttorneyName }}
     <br>Power of attorney

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -15,14 +15,19 @@
     Patient
   {% elseif data.consent == "Clinician following the Mental Capacity Act" %}
     {{ data.consentClinicianName }}
+    <br>Clinician
   {% elseif data.consent == "Person with power of attorney for personal welfare" %}
     {{ data.consentAttorneyName }}
+    <br>Power of attorney
   {% elseif data.consent == "Parent or guardian" %}
     {{ data.consentParentName }}
+    <br>Parent or guardian
   {% elseif data.consent == "Mental capacity advocate" %}
     {{ data.consentAdvocateName }}
+    <br>Mental capacity advocate
   {% elseif data.consent == "Court appointed deputy" %}
     {{ data.consentDeputyName }}
+    <br>Court appointed deputy
   {% endif %}
 {% endset %}
 
@@ -253,7 +258,7 @@
               text: "Consent given by"
             },
             value: {
-              text: consentHtml
+              html: consentHtml
             },
             actions: {
               items: [

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -11,10 +11,18 @@
 {% endblock %}
 
 {% set consentHtml %}
-  {% if data.consent == data.patientName %}
+  {% if data.consent == "patient" %}
     Patient
-  {% else %}
-    {{ data.consentName | first }}, {{ data.consent }}
+  {% elseif data.consent == "Clinician following the Mental Capacity Act" %}
+    {{ data.consentClinicianName }}
+  {% elseif data.consent == "Person with power of attorney for personal welfare" %}
+    {{ data.consentAttorneyName }}
+  {% elseif data.consent == "Parent or guardian" %}
+    {{ data.consentParentName }}
+  {% elseif data.consent == "Mental capacity advocate" %}
+    {{ data.consentAdvocateName }}
+  {% elseif data.consent == "Court appointed deputy" %}
+    {{ data.consentDeputyName }}
   {% endif %}
 {% endset %}
 

--- a/app/views/vaccinate/consent.html
+++ b/app/views/vaccinate/consent.html
@@ -19,19 +19,84 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form action="/vaccinate/injection-site" method="post" novalidate>
+      {% if (errors | length) > 0 %}
+        {{ errorSummary({
+          titleText: "There is a problem",
+          errorList: errors
+        }) }}
+      {% endif %}
 
-        {% set otherConsentHtml %}
 
+      <form action="/vaccinate/answer-consent" method="post" novalidate>
+
+        {% set consentClinicianHtml %}
           {{ input({
             label: {
               text: "Name"
             },
-            id: "consentName",
-            name: "consentName",
-            value: ((data.consentName | first) if data.cosentName else "")
+            errorMessage: {
+              text: consentClinicianError.text
+            } if consentClinicianError,
+            id: "consent-clinician-name",
+            name: "consentClinicianName",
+            value: data.consentClinicianName
           }) }}
+        {% endset %}
 
+        {% set consentAttorneyHtml %}
+          {{ input({
+            label: {
+              text: "Name"
+            },
+            errorMessage: {
+              text: consentAttorneyError.text
+            } if consentAttorneyError,
+            id: "consent-attorney-name",
+            name: "consentAttorneyName",
+            value: data.consentAttorneyName
+          }) }}
+        {% endset %}
+
+        {% set consentParentHtml %}
+          {{ input({
+            label: {
+              text: "Name"
+            },
+            errorMessage: {
+              text: consentParentError.text
+            } if consentParentError,
+            id: "consent-parent-name",
+            name: "consentParentName",
+            value: data.consentParentName
+          }) }}
+        {% endset %}
+
+        {% set consentAdvocateHtml %}
+          {{ input({
+            label: {
+              text: "Name"
+            },
+            errorMessage: {
+              text: consentAdvocateError.text
+            } if consentAdvocateError,
+            id: "consent-advocate-name",
+            name: "consentAdvocateName",
+            value: data.consentAdvocateName
+          }) }}
+        {% endset %}
+
+        {% set consentDeputyHtml %}
+          {{ input({
+            label: {
+              text: "Name"
+            },
+            errorMessage: {
+              text: consentDeputyError.text
+            } if consentDeputyError,
+            id: "consent-deputy-name",
+            name: "consentDeputyName",
+            value: data.consentDeputyName
+          }) }}
         {% endset %}
 
         {{ radios({
@@ -44,11 +109,14 @@
               isPageHeading: "true"
             }
           },
+          errorMessage: {
+            text: consentError.text
+          } if consentError,
           items: [
             {
-              value: data.patientName,
-              text: data.patientName,
-              checked: (data.consent === data.patientName)
+              value: 'patient',
+              text: (data.patientName or "Jodie Brown"),
+              checked: (data.consent === 'patient')
             },
             {
               divider: "or"
@@ -58,7 +126,7 @@
               text: "Clinician following the Mental Capacity Act",
               checked: (data.consent === "Clinician following the Mental Capacity Act"),
               conditional: {
-                html: otherConsentHtml
+                html: consentClinicianHtml
               }
             },
             {
@@ -66,7 +134,7 @@
                 text: "Person with power of attorney for personal welfare",
                 checked: (data.consent === "Person with power of attorney for personal welfare"),
                 conditional: {
-                  html: otherConsentHtml
+                  html: consentAttorneyHtml
                 }
               },
               {
@@ -74,7 +142,7 @@
                 text: "Parent or guardian",
                 checked: (data.consent === "Parent or guardian"),
                 conditional: {
-                  html: otherConsentHtml
+                  html: consentParentHtml
                 }
               },
               {
@@ -82,7 +150,7 @@
                 text: "Mental capacity advocate",
                 checked: (data.consent === "Mental capacity advocate"),
                 conditional: {
-                  html: otherConsentHtml
+                  html: consentAdvocateHtml
                 }
               },
               {
@@ -90,7 +158,7 @@
                 text: "Court appointed deputy",
                 checked: (data.consent === "Court appointed deputy"),
                 conditional: {
-                  html: otherConsentHtml
+                  html: consentDeputyHtml
                 }
               }
           ]

--- a/app/views/vaccinate/consent.html
+++ b/app/views/vaccinate/consent.html
@@ -122,9 +122,9 @@
               divider: "or"
             },
             {
-              value: "Clinician following the Mental Capacity Act",
-              text: "Clinician following the Mental Capacity Act",
-              checked: (data.consent === "Clinician following the Mental Capacity Act"),
+              value: "Clinician acting in the patient’s best interests",
+              text: "Clinician acting in the patient’s best interests",
+              checked: (data.consent === "Clinician acting in the patient’s best interests"),
               conditional: {
                 html: consentClinicianHtml
               }


### PR DESCRIPTION
This adds some error messages shown on the consent page and also adds the consent type to the Check your answers page.

## No option selected

![Screenshot 2025-02-03 at 14 17 24](https://github.com/user-attachments/assets/431b0795-211f-40c0-bd3a-75400451df89)

## Someone other than the patient selected, but no name entered

![Screenshot 2025-02-03 at 14 19 29](https://github.com/user-attachments/assets/02461dfa-a624-4368-b6ec-4bbacefa36af)

## Check your answers page

![Screenshot 2025-02-03 at 14 20 30](https://github.com/user-attachments/assets/7eb7eeb7-d526-48d6-a6eb-b034664b8646)
