### PR TITLE
Changed POA consent words and location type

### DIFF
--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -16,7 +16,7 @@
   {% elseif data.consent == "Clinician acting in the patient’s best interests" %}
     {{ data.consentClinicianName }}
     <br>Clinician
-  {% elseif data.consent == "Person with power of attorney for personal welfare" %}
+  {% elseif data.consent == "Person with power of attorney for health and welfare" %}
     {{ data.consentAttorneyName }}
     <br>Power of attorney
   {% elseif data.consent == "Parent or guardian" %}
@@ -204,7 +204,7 @@
           },
           {
             key: {
-              text: "Location"
+              text: "Location type"
             },
             value: {
               html: data.locationType


### PR DESCRIPTION
On Check and confirm screen, changed POA consent wording to 'Person with power of attorney for health and welfare' and changed 'Location' label (used for care model) to 'Location type'