### PR TITLE
Merge vaccine rows in check answers

### DIFF
--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -139,7 +139,7 @@
               text: "Vaccine"
             },
             value: {
-              text: data.vaccine
+              html: data.vaccine + "<br>" + data.vaccineProduct
             },
             actions: {
               items: [
@@ -147,23 +147,6 @@
                   href: "/vaccinate/vaccine",
                   text: "Change",
                   visuallyHiddenText: "vaccine"
-                }
-              ]
-            }
-          },
-          {
-            key: {
-              text: "Product"
-            },
-            value: {
-              text: data.vaccineProduct
-            },
-            actions: {
-              items: [
-                {
-                  href: "/vaccinate/vaccine",
-                  text: "Change",
-                  visuallyHiddenText: "vaccine product"
                 }
               ]
             }


### PR DESCRIPTION
This merges the 2 vaccine answers, vaccine type and product name, into a single 'row' within the check-answers page.

This is because they’re conceptually related and both relate to the 'vaccine', and they’re asked on the same page, so only a single 'change' link is needed.

## Screenshots

| Before    |  After |
|----|----|
| <img width="681" alt="Screenshot 2025-02-04 at 12 28 21" src="https://github.com/user-attachments/assets/d3b28e11-cd8f-46cd-8ab2-76d9fe70a929" /> | <img width="667" alt="Screenshot 2025-02-04 at 12 28 01" src="https://github.com/user-attachments/assets/5b8b8733-d891-4f06-9a47-7e382a9d7cb7" /> |

