### PR TITLE
Add team to check answers page

### DIFF
--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -170,6 +170,23 @@
           },
           {
             key: {
+              text: "Team"
+            },
+            value: {
+              text: data.deliveryTeam
+            },
+            actions: {
+              items: [
+                {
+                  href: "/vaccinate/delivery-team",
+                  text: "Change",
+                  visuallyHiddenText: "team"
+                }
+              ]
+            }
+          },
+          {
+            key: {
               text: "Vaccinator"
             },
             value: {


### PR DESCRIPTION
We missed this before.

## Screenshot

<img width="715" alt="Screenshot 2025-02-04 at 12 41 35" src="https://github.com/user-attachments/assets/d73b0e29-f5e1-42e6-8f02-ac39413b9b31" />
