### PR TITLE
Default NHS number known to 'yes'

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,4 +1,5 @@
 module.exports = {
+  nhsNumberKnown: "yes",
   currentUserId: "12345",
   currentOrganisationId: "R0A",
   vaccines: [

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -457,6 +457,7 @@ module.exports = router => {
     data.consentParentName = ""
     data.consentAdvocateName = ""
     data.consentDeputyName = ""
+    data.nhsNumberKnown = "yes"
 
     if (answer === 'same-vaccination-another-patient') {
 


### PR DESCRIPTION
We’ve decided to default this question to 'Yes', as NHS number is used around ~90% of the time, and so it saves a click.

This also is very low-risk as even if someone doesn’t realise the default has been set, if they click Continue without entering an NHS number there will be an error.

See https://nhsd-jira.digital.nhs.uk/browse/RAVS-1573

## Screenshot

<img width="1013" alt="Screenshot 2025-02-06 at 10 39 28" src="https://github.com/user-attachments/assets/7a8eba7c-be16-438f-9f00-61f2478b1b1d" />

