### PR TITLE
Update consent screen

### DIFF
--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -644,7 +644,7 @@ module.exports = router => {
 
         if (consentAttorneyRelationship === '') {
           consentAttorneyRelationshipError = {
-            text: "Enter relationship to the patient",
+            text: "Enter the relationship to the patient",
             href: "#consent-attorney-relationship"
           }
           errors.push(consentAttorneyRelationshipError)

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -607,7 +607,7 @@ module.exports = router => {
 
   router.get('/vaccinate/consent', (req, res) => {
     let errors = []
-    let consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError
+    let consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError, consentAttorneyRelationshipError
     const data = req.session.data
     const consent = data.consent
     const consentClinicianName = data.consentClinicianName
@@ -615,6 +615,8 @@ module.exports = router => {
     const consentParentName = data.consentParentName
     const consentAdvocateName = data.consentAdvocateName
     const consentDeputyName = data.consentDeputyName
+    const consentDeputyRelationship = data.consentDeputyRelationship
+    const consentAttorneyRelationship = data.consentAttorneyRelationship
 
     if (req.query.showErrors === 'yes') {
       if (!consent) {
@@ -630,13 +632,24 @@ module.exports = router => {
           href: "#consent-clinician-name"
         }
         errors.push(consentClinicianError)
-      } else if (consent === "Person with power of attorney for personal welfare" && consentAttorneyName === '') {
+      } else if (consent === "Person with lasting power of attorney for health and welfare") {
 
-        consentAttorneyError = {
-          text: "Enter a name",
-          href: "#consent-attorney-name"
+        if (consentAttorneyName === '') {
+          consentAttorneyError = {
+            text: "Enter a name",
+            href: "#consent-attorney-name"
+          }
+          errors.push(consentAttorneyError)
         }
-        errors.push(consentAttorneyError)
+
+        if (consentAttorneyRelationship === '') {
+          consentAttorneyRelationshipError = {
+            text: "Enter relationship to the patient",
+            href: "#consent-attorney-relationship"
+          }
+          errors.push(consentAttorneyRelationshipError)
+        }
+
       } else if (consent === "Parent or guardian" && consentParentName === '') {
 
         consentParentError = {
@@ -651,18 +664,29 @@ module.exports = router => {
           href: "#consent-advocate-name"
         }
         errors.push(consentAdvocateError)
-      } else if (consent === "Court appointed deputy" && consentDeputyName === '') {
+      } else if (consent === "Court appointed deputy") {
 
-        consentDeputyError = {
-          text: "Enter a name",
-          href: "#consent-deputy-name"
+        if (consentDeputyName === '') {
+          consentDeputyError = {
+            text: "Enter a name",
+            href: "#consent-deputy-name"
+          }
+          errors.push(consentDeputyError)
         }
-        errors.push(consentDeputyError)
+
+        if (consentDeputyRelationship === '') {
+          consentDeputyRelationshipError = {
+            text: "Enter the relationship to the patient",
+            href: "#consent-deputy-relationship"
+          }
+          errors.push(consentDeputyRelationshipError)
+        }
+
       }
     }
 
     res.render('vaccinate/consent', {
-      errors, consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError
+      errors, consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError, consentAttorneyRelationshipError, consentDeputyRelationshipError
     })
   })
 
@@ -674,14 +698,16 @@ module.exports = router => {
     const consentParentName = data.consentParentName
     const consentAdvocateName = data.consentAdvocateName
     const consentDeputyName = data.consentDeputyName
+    const consentDeputyRelationship = data.consentDeputyRelationship
+    const consentAttorneyRelationship = data.consentAttorneyRelationship
 
     if (
       (consent === "patient") ||
       (consent === "Clinician acting in the patient’s best interests" && consentClinicianName != '') ||
-      (consent === "Person with power of attorney for personal welfare" && consentAttorneyName != '') ||
+      (consent === "Person with lasting power of attorney for health and welfare" && consentAttorneyName != '' && consentAttorneyRelationship != '') ||
       (consent === "Parent or guardian" && consentParentName != '') ||
-      (consent === "Mental capacity advocate" && consentAdvocateName != '') ||
-      (consent === "Court appointed deputy" && consentDeputyName != '')
+      (consent === "Independent mental capacity advocate" && consentAdvocateName != '') ||
+      (consent === "Court appointed deputy" && consentDeputyName != '' && consentDeputyRelationship != "")
     ) {
       res.redirect('/vaccinate/injection-site')
     } else {

--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -607,7 +607,7 @@ module.exports = router => {
 
   router.get('/vaccinate/consent', (req, res) => {
     let errors = []
-    let consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError, consentAttorneyRelationshipError
+    let consentError, consentClinicianError, consentAttorneyError, consentParentError, consentAdvocateError, consentDeputyError, consentAttorneyRelationshipError, consentDeputyRelationshipError
     const data = req.session.data
     const consent = data.consent
     const consentClinicianName = data.consentClinicianName

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -16,6 +16,7 @@
     <br>Clinician
   {% elseif data.consent == "Person with lasting power of attorney for health and welfare" %}
     {{ data.consentAttorneyName }}
+    <br>{{ data.consentAttorneyRelationship }}
     <br>Power of attorney
   {% elseif data.consent == "Parent or guardian" %}
     {{ data.consentParentName }}
@@ -25,6 +26,7 @@
     <br>Independent mental capacity advocate
   {% elseif data.consent == "Court appointed deputy" %}
     {{ data.consentDeputyName }}
+    <br>{{ data.consentDeputyRelationship }}
     <br>Court appointed deputy
   {% endif %}
 {% endset %}

--- a/app/views/vaccinate/check.html
+++ b/app/views/vaccinate/check.html
@@ -14,15 +14,15 @@
   {% elseif data.consent == "Clinician acting in the patient’s best interests" %}
     {{ data.consentClinicianName }}
     <br>Clinician
-  {% elseif data.consent == "Person with power of attorney for health and welfare" %}
+  {% elseif data.consent == "Person with lasting power of attorney for health and welfare" %}
     {{ data.consentAttorneyName }}
     <br>Power of attorney
   {% elseif data.consent == "Parent or guardian" %}
     {{ data.consentParentName }}
     <br>Parent or guardian
-  {% elseif data.consent == "Mental capacity advocate" %}
+  {% elseif data.consent == "Independent mental capacity advocate" %}
     {{ data.consentAdvocateName }}
-    <br>Mental capacity advocate
+    <br>Independent mental capacity advocate
   {% elseif data.consent == "Court appointed deputy" %}
     {{ data.consentDeputyName }}
     <br>Court appointed deputy

--- a/app/views/vaccinate/consent.html
+++ b/app/views/vaccinate/consent.html
@@ -53,6 +53,18 @@
             name: "consentAttorneyName",
             value: data.consentAttorneyName
           }) }}
+
+          {{ input({
+            label: {
+              text: "Relationship to the patient"
+            },
+            errorMessage: {
+              text: consentClinicianRelationshipError.text
+            } if consentClinicianRelationshipError,
+            id: "consent-clinician-relationship-name",
+            name: "consentClinicianRelationship",
+            value: data.consentClinicianRelationship
+          }) }}
         {% endset %}
 
         {% set consentParentHtml %}
@@ -95,6 +107,18 @@
             name: "consentDeputyName",
             value: data.consentDeputyName
           }) }}
+
+          {{ input({
+            label: {
+              text: "Relationship to the patient"
+            },
+            errorMessage: {
+              text: consentDeputyRelationshipError.text
+            } if consentDeputyRelationshipError,
+            id: "consent-deputy-relationship-name",
+            name: "consentDeputyRelationship",
+            value: data.consentDeputyRelationship
+          }) }}
         {% endset %}
 
         {{ radios({
@@ -128,9 +152,9 @@
               }
             },
             {
-                value: "Person with power of attorney for health and welfare",
-                text: "Person with power of attorney for health and welfare",
-                checked: (data.consent === "Person with power of attorney for health and welfare"),
+                value: "Person with lasting power of attorney for health and welfare",
+                text: "Person with lasting power of attorney for health and welfare",
+                checked: (data.consent === "Person with lasting power of attorney for health and welfare"),
                 conditional: {
                   html: consentAttorneyHtml
                 }
@@ -144,9 +168,9 @@
                 }
               },
               {
-                value: "Mental capacity advocate",
-                text: "Mental capacity advocate",
-                checked: (data.consent === "Mental capacity advocate"),
+                value: "Independent mental capacity advocate",
+                text: "Independent mental capacity advocate",
+                checked: (data.consent === "Independent mental capacity advocate"),
                 conditional: {
                   html: consentAdvocateHtml
                 }

--- a/app/views/vaccinate/consent.html
+++ b/app/views/vaccinate/consent.html
@@ -59,11 +59,11 @@
               text: "Relationship to the patient"
             },
             errorMessage: {
-              text: consentClinicianRelationshipError.text
-            } if consentClinicianRelationshipError,
-            id: "consent-clinician-relationship-name",
-            name: "consentClinicianRelationship",
-            value: data.consentClinicianRelationship
+              text: consentAttorneyRelationshipError.text
+            } if consentAttorneyRelationshipError,
+            id: "consent-attorney-relationship",
+            name: "consentAttorneyRelationship",
+            value: data.consentAttorneyRelationship
           }) }}
         {% endset %}
 
@@ -115,7 +115,7 @@
             errorMessage: {
               text: consentDeputyRelationshipError.text
             } if consentDeputyRelationshipError,
-            id: "consent-deputy-relationship-name",
+            id: "consent-deputy-relationship",
             name: "consentDeputyRelationship",
             value: data.consentDeputyRelationship
           }) }}


### PR DESCRIPTION
Following user research, we’ve decided to add a 'relationship to the patient' field back in where the consent is based on lasting power of attorney or a court appointed deputy.

We’ve also update the wording slightly:

* Person with power of attorney for health and welfare => Person with lasting power of attorney for health and welfare
* Mental capacity advocate => Independent mental capacity advocate

Jira card: https://nhsd-jira.digital.nhs.uk/browse/RAVS-1546

## Screenshots

<img width="846" alt="Screenshot 2025-02-06 at 10 56 19" src="https://github.com/user-attachments/assets/b5016204-e154-475f-b8ed-88eac01bbf06" />

<img width="861" alt="Screenshot 2025-02-06 at 11 01 29" src="https://github.com/user-attachments/assets/d49afa70-7f1a-47ec-9531-abd0bfd9eacc" />

### Error states

![Screenshot 2025-02-07 at 15 15 32](https://github.com/user-attachments/assets/e718b5b0-ed95-4d39-94d4-5ea0b9428e4b)

![consent-error](https://github.com/user-attachments/assets/a4cdbf9e-1561-425a-846f-07c0b596d000)

### Check your answers summary

<img width="722" alt="Screenshot 2025-02-06 at 11 28 32" src="https://github.com/user-attachments/assets/b16e8ee8-41f2-47ce-b4b9-167b32270cc5" />

<img width="840" alt="Screenshot 2025-02-06 at 11 24 11" src="https://github.com/user-attachments/assets/fd3df09c-dc18-44df-a5ac-a8f05adf83df" />

