### PR TITLE
Update vaccination saved page

### DIFF
--- a/app/assets/sass/components/_panel.scss
+++ b/app/assets/sass/components/_panel.scss
@@ -53,3 +53,7 @@ $nhsuk-border-width-panel: nhsuk-spacing(1);
 .nhsuk-panel__title:last-child {
   margin-bottom: 0;
 }
+
+.nhsuk-panel a {
+  color: $color_nhsuk-white;
+}

--- a/app/views/vaccinate/done.html
+++ b/app/views/vaccinate/done.html
@@ -11,7 +11,7 @@
       <div class="nhsuk-panel nhsuk-u-margin-bottom-8">
         <h1 class="nhsuk-panel__title">Vaccination saved</h1>
         <div class="nhsuk-panel__body">
-          The record will be sent to {{ data.patientName }}’s GP.
+          <a href="#">{{ data.patientName }}’s {{ data.vaccine }} record</a> will be sent to their GP.
         </div>
       </div>
 
@@ -22,25 +22,25 @@
           name: "nextStep",
           fieldset: {
             legend: {
-              text: "What would you like to do next?",
+              text: "What would you like to record now?",
               classes: "nhsuk-fieldset__legend--m"
             }
           },
           items: [
             {
-              value: "same-vaccination-another-patient",
-              text: "Record a " + data.vaccine + " vaccination for another patient"
+              value: "same-patient-another-vaccination",
+              text: data.patientName + "’s next vaccination"
             },
             {
-              value: "same-patient-another-vaccination",
-              text: "Record another vaccination for " + data.patientName
+              value: "same-vaccination-another-patient",
+              text: "A " + (data.vaccine | lower) + " vaccination for another patient"
             },
             {
               divider: "or"
             },
             {
               value: "done",
-              text: "I’m finished vaccinating for now"
+              text: "A different vaccination for another patient"
             }
 
           ]

--- a/app/views/vaccinate/done.html
+++ b/app/views/vaccinate/done.html
@@ -33,7 +33,7 @@
             },
             {
               value: "same-vaccination-another-patient",
-              text: "A " + (data.vaccine | lower) + " vaccination for another patient"
+              text: ("An RSV" if data.vaccine == "RSV" else ("A " + data.vaccine | lower)) + " vaccination for another patient"
             },
             {
               divider: "or"


### PR DESCRIPTION
We’ve decided to:

* add a link to view the record - in case they now realise they’ve just made an error and need to correct it, or just need some extra reassurance
* change the wording of the options for what to do next
* added an option to record a different vaccination for a different patient
* removed the 'I’m finished’ option, as we think users could just browse away or log out instead

## Screenshots

### Before

![done-before](https://github.com/user-attachments/assets/c43a2e2a-ed43-4369-a74f-41e7676f50ef) 

### After

![done-after](https://github.com/user-attachments/assets/fcf037f2-fa42-40d2-b468-836327b8039a) 