### PR TITLE
Update page titles

### DIFF
--- a/app/views/vaccinate/add-batch.html
+++ b/app/views/vaccinate/add-batch.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Add batch
+  Add a batch
 {% endblock %}
 
 {% set currentSection = "vaccines" %}

--- a/app/views/vaccinate/batch.html
+++ b/app/views/vaccinate/batch.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Batch" %}
+{% set pageName = "Which batch are you using?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/consent.html
+++ b/app/views/vaccinate/consent.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Consent" %}
+{% set pageName = "Who is giving consent?" %}
 
 {% set currentSection = "consent" %}
 

--- a/app/views/vaccinate/delivery-team.html
+++ b/app/views/vaccinate/delivery-team.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Team" %}
+{% set pageName = "Which team are you working with?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/eligibility.html
+++ b/app/views/vaccinate/eligibility.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Eligibility" %}
+{% set pageName = "Why are you giving them the vaccine?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/index.html
+++ b/app/views/vaccinate/index.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Vaccination date" %}
+{% set pageName = "Is the vaccination today?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/injection-site.html
+++ b/app/views/vaccinate/injection-site.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Injection site" %}
+{% set pageName = "Where did you give the injection?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/location.html
+++ b/app/views/vaccinate/location.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Location" %}
+{% set pageName = "Where is the vaccination taking place?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-pertussis-warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Are you sure you want to continue?" %}
+{% set pageName = "Pertussis vaccine warning" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
+++ b/app/views/vaccinate/patient-estimated-due-date-rsv-warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Are you sure you want to continue?" %}
+{% set pageName = "RSV vaccine warning" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/patient-estimated-due-date.html
+++ b/app/views/vaccinate/patient-estimated-due-date.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Estimated due date" %}
+{% set pageName = "What is the patient's estimated due date?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Check patient details" %}
+{% set pageName = "Check the patient details" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/vaccinator.html
+++ b/app/views/vaccinate/vaccinator.html
@@ -1,8 +1,8 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Vaccinator" %}
+{% set pageName = "Who is the vaccinator?" %}
 
-{% set currentSection = "Who is the vaccinator?" %}
+{% set currentSection = "Vaccinate" %}
 
 {% block beforeContent %}
   {{ backLink({ href: "/vaccinate/delivery-team" }) }}

--- a/app/views/vaccinate/vaccinator.html
+++ b/app/views/vaccinate/vaccinator.html
@@ -2,7 +2,7 @@
 
 {% set pageName = "Who is the vaccinator?" %}
 
-{% set currentSection = "Vaccinate" %}
+{% set currentSection = "vaccinate" %}
 
 {% block beforeContent %}
   {{ backLink({ href: "/vaccinate/delivery-team" }) }}

--- a/app/views/vaccinate/vaccinator.html
+++ b/app/views/vaccinate/vaccinator.html
@@ -2,7 +2,7 @@
 
 {% set pageName = "Vaccinator" %}
 
-{% set currentSection = "vaccinate" %}
+{% set currentSection = "Who is the vaccinator?" %}
 
 {% block beforeContent %}
   {{ backLink({ href: "/vaccinate/delivery-team" }) }}

--- a/app/views/vaccinate/vaccine.html
+++ b/app/views/vaccinate/vaccine.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Vaccine" %}
+{% set pageName = "Which vaccine are you giving?" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/vaccinate/warning.html
+++ b/app/views/vaccinate/warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Are you sure you want to continue?" %}
+{% set pageName = "COVID-19 vaccine interval warning" %}
 
 {% set currentSection = "vaccinate" %}
 


### PR DESCRIPTION
Have updated page titles for the Record journey. The default format we have agreed on for now is "H1 - NHS Record a vaccination"

Most page titles are now aligned with the H1, with these exceptions: 
- Patient details (have kept it a bit shorter)
- Any screen mentioning patient name (the page title will say 'patient' instead of the name)
- Warnings (have done shorter titles as the actual H1s are long and contain personal info)