### PR TITLE
Changes to covid interval warning

### DIFF
--- a/app/views/vaccinate/warning.html
+++ b/app/views/vaccinate/warning.html
@@ -12,10 +12,10 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Are you sure you want to continue?</h1>
+      <h1 class="nhsuk-heading-l">{{ data.patientName }} had a COVID-19 vaccine less than 3 months ago</h1>
 
       <p>
-        {{ data.patientName }} had a COVID-19 vaccine less than 3 months ago, on 1&nbsp;December 2024.
+        {{ data.patientName }} had a COVID-19 vaccine on 1&nbsp;December 2024.
       </p>
 
       <p>
@@ -29,7 +29,7 @@ UKHSA guidance on COVID-19 vaccination (opens in new tab)</a>.
   </div>
 
   {{ button({
-    "text": "Continue",
+    "text": "Continue anyway",
     "href": "/vaccinate/consent"
   }) }}
 


### PR DESCRIPTION
Changed H1 to 'Patient name had a COVID-19 vaccine less than 3 months ago'

Move info about the date they had the vaccine into main body of the screen. 

Changed button text to 'Continue anyway'

<img width="719" alt="Screenshot 2025-02-11 at 13 30 12" src="https://github.com/user-attachments/assets/c72e38c1-6066-42a8-8b14-5e906c00ddd4" />
