### PR TITLE
Fix rendering of due date on find-a-record check screen

### DIFF
--- a/app/views/find-a-record/check.html
+++ b/app/views/find-a-record/check.html
@@ -158,7 +158,7 @@
               text: "Pregnancy due date"
             },
             value: {
-              text: (vaccination.pregnancyDueDate | govukDate)
+              text: (vaccination.pregnancyDueDate | isoDateFromDateInput | govukDate)
             },
             actions: {
               items: [


### PR DESCRIPTION
Previously was displaying `Invalid DateTime` as the date.