### PR TITLE
Enable functionality for changing batch number

### DIFF
--- a/app/routes/find-record.js
+++ b/app/routes/find-record.js
@@ -55,6 +55,9 @@ module.exports = router => {
     if (data.consent) {
       vaccination.consent = data.consent
     }
+    if(data.batchNumber) {
+      vaccination.batchNumber = data.batchNumber
+    }
 
     res.redirect(`/find-a-record/records/${id}?changedField=${data.changedField}`)
 

--- a/app/views/find-a-record/batch.html
+++ b/app/views/find-a-record/batch.html
@@ -17,11 +17,12 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <form action="/find-a-record/check-confirm?changedField=Batch" method="post">
+      <form action="/find-a-record/records/{{ vaccination.id }}" method="post">
+        <input type="hidden" name="changedField" value="Batch">
 
           {{ radios({
-            "idPrefix": "vaccineBatch",
-            "name": "vaccineBatch",
+            "idPrefix": "batchNumber",
+            "name": "batchNumber",
             "fieldset": {
               "legend": {
                 "text": ("Which batch was used?" if vaccination.vaccinationToday == 'yes' else "Which batch was used?"),


### PR DESCRIPTION
Previously, trying to change a batch would take you to the wrong URL, causing the data to become invalid.

N.B this will allow you to change the batch number, but the expiry date will not change