### PR TITLE
Add age to patient details and show patient history again when doing co-admin

### DIFF
--- a/app/routes/vaccinate.js
+++ b/app/routes/vaccinate.js
@@ -427,7 +427,7 @@ module.exports = router => {
       if (data.vaccine === "Pertussis" || ((data.vaccine == "RSV") && (eligibility === "Pregnant"))) {
         nextPage = "/vaccinate/patient-estimated-due-date"
       } else {
-        nextPage = "/vaccinate/consent"
+        nextPage = "/vaccinate/patient-history"
       }
 
     } else {

--- a/app/views/find-a-record/patient-history.html
+++ b/app/views/find-a-record/patient-history.html
@@ -13,7 +13,7 @@
 {% set dateOfBirthHtml %}
   {% if data.dateOfBirth %}
     {{ (data.dateOfBirth | isoDateFromDateInput | govukDate) }}
-    <br>(aged 75)
+    <br>(75 years old)
   {% endif %}
 {% endset %}
 

--- a/app/views/find-a-record/patient-history.html
+++ b/app/views/find-a-record/patient-history.html
@@ -10,6 +10,13 @@
   {{ backLink({ href: "/find-a-record/search-result" }) }}
 {% endblock %}
 
+{% set dateOfBirthHtml %}
+  {% if data.dateOfBirth %}
+    {{ (data.dateOfBirth | isoDateFromDateInput | govukDate) }}
+    <br>(aged 75)
+  {% endif %}
+{% endset %}
+
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -40,7 +47,7 @@
               text: "Date of birth"
             },
             value: {
-              text: (data.dateOfBirth | isoDateFromDateInput | govukDate) if data.dateOfBirth
+              html: dateOfBirthHtml
             }
           },
           {

--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -15,7 +15,7 @@
 {% set dateOfBirthHtml %}
   {% if data.dateOfBirth %}
     {{ (data.dateOfBirth | isoDateFromDateInput | govukDate) }}
-    <br>(aged 75)
+    <br>(75 years old)
   {% endif %}
 {% endset %}
 

--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -12,6 +12,13 @@
   {% set nextPage = "/vaccinate/consent" %}
 {% endif %}
 
+{% set dateOfBirthHtml %}
+  {% if data.dateOfBirth %}
+    {{ (data.dateOfBirth | isoDateFromDateInput | govukDate) }}
+    <br>(aged 75)
+  {% endif %}
+{% endset %}
+
 {% block beforeContent %}
   {{ backLink({ href: "/vaccinate/patient" }) }}
 {% endblock %}
@@ -38,7 +45,7 @@
               text: "Date of birth"
             },
             value: {
-              text: ((data.dateOfBirth | isoDateFromDateInput | govukDate) if data.dateOfBirth else "")
+              html: dateOfBirthHtml
             }
           },
           {


### PR DESCRIPTION
This displays the patient’s age on the Check patient page:

![Screenshot 2025-02-14 at 15 32 43](https://github.com/user-attachments/assets/0fffffcf-6d3c-4f4b-92fd-2e601fe48e56)

It also shows the patient history again when doing the 2nd vaccination for the same patient (co-admin).

🗂️ [Jira card](https://nhsd-jira.digital.nhs.uk/browse/RAVS-1544)
