### PR TITLE
Update to vax history explainer text on patient details screen

### DIFF
--- a/app/views/vaccinate/patient-history.html
+++ b/app/views/vaccinate/patient-history.html
@@ -86,9 +86,9 @@
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
 
-      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, pertussis and RSV vaccinations.</p>
+      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, pertussis and RSV.</p>
 
-      <p>However, if an RSV or pertussis vaccination was given at a GP practice, it will not show here.</p>
+      <p>However, pertussis vaccinations given at a GP surgery are not shown.</p>
     </div>
   </div>
   <div class="nhsuk-grid-row">


### PR DESCRIPTION
Update to reflect that RSV vax given at GPs now do show on vax history.