### PR TITLE
Updated text on No search result screen

### DIFF
--- a/app/views/vaccinate/no-search-result.html
+++ b/app/views/vaccinate/no-search-result.html
@@ -110,7 +110,7 @@
         }) }}
       </form>
 
-      <p>You can continue and record a vaccination without an NHS number, however the record will not be sent to a GP.</p>
+      <p>If you've tried searching several times and cannot find an existing patient record, you can continue and record a vaccination without an NHS number.</p>
 
       {{ button({
           text: "Continue with no NHS number",


### PR DESCRIPTION
Changed the text to reinforce you should search several times before continuing with no NHS number. And removed the text saying this record is not sent to the GP as not sure that's 100% correct - if the record is reconciled then presumably it would reach the GP.