### PR TITLE
Updated text for 'Before you start' screen

### DIFF
--- a/app/views/vaccinate/empty.html
+++ b/app/views/vaccinate/empty.html
@@ -9,11 +9,10 @@
     <div class="nhsuk-grid-column-two-thirds">
 
         <h1 class="nhsuk-heading-l">Record vaccinations</h1>
-        <p class="nhsuk-body-l">Before you start, you need to make sure at least one user has 'clinician' status, and you need to add vaccines.</p>
+        <p class="nhsuk-body-l">Before you start, at least 1 user at your organisation must have "clinician" status.</p>
 
-        <p class="nhsuk-body-l"> <a href="/user-admin/add-user" class="nhsuk-link nhsuk-link--no-visited-state">Add a clinician</a></p>
-        <p class="nhsuk-body-l"> <a href="/vaccines/choose-site" class="nhsuk-link nhsuk-link--no-visited-state">Add vaccines</a></p>
-       
+        <p class="nhsuk-body-l">A lead administrator can add or change a user.</p>
+              
 
     </div>
   </div>


### PR DESCRIPTION
Updated text. This version can be used for any user, irrespective of permissions. 

This example is for when a user tries to record when there is no-one at their org with 'clinician' status. 

There are 2 other variations of the wording on this screen: for when no vax have been added, and for when no vax AND no clinician have been added.