### PR TITLE
Change email address section of Add user page

### DIFF
--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -79,7 +79,7 @@
             "text": "NHS-approved email address"
           },
           hint: {
-            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list">Care Identity email allow list (opens in new tab)</a>."
+            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab)</a>.
           },
           "id": "email",
           "name": "email",

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
-      <p>Users must have an NHS-approved email address. For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab)</a>.</p>
+      <p>Users must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">list of approved email domains(opens in new tab)</a>.</p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
-      <p>Users must have an NHS-approved email address. For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab).</a></p>
+      <p>Users must have an NHS-approved email address. For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab)</a>.</p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,6 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
+      <p class="nhsuk-body-l">Users must have an NHS-approved email address. For a list of approved domains, see the Care Identiy email allow list (opens in new tab).</p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
-      <p class="nhsuk-body-l">Users must have an NHS-approved email address. For a list of approved domains, see the href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab).</a></p>
+      <p>Users must have an NHS-approved email address. For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab).</a></p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
-      <p>Users must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">list of approved email domains(opens in new tab)</a>.</p>
+      <p>Users must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">list of approved email domains (opens in new tab)</a>.</p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -78,9 +78,6 @@
           "label": {
             "text": "NHS-approved email address"
           },
-          hint: {
-            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab)</a>.
-          },
           "id": "email",
           "name": "email",
           type: "email",

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -45,7 +45,7 @@
       {% endif %}
 
       <h1 class="nhsuks-heading-xl">Add user</h1>
-      <p class="nhsuk-body-l">Users must have an NHS-approved email address. For a list of approved domains, see the Care Identiy email allow list (opens in new tab).</p>
+      <p class="nhsuk-body-l">Users must have an NHS-approved email address. For a list of approved domains, see the href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">Care Identity email allow list (opens in new tab).</a></p>
 
       <form action="/user-admin/check-answers" method="post" novalidate="true">
 

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -76,7 +76,10 @@
 
         {{ input({
           "label": {
-            "text": "NHS email address"
+            "text": "NHS-approved email address"
+          },
+          hint: {
+            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list">Care Identity                email allow list (opens in new tab)</a>
           },
           "id": "email",
           "name": "email",

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -79,7 +79,7 @@
             "text": "NHS-approved email address"
           },
           hint: {
-            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list">Care Identity                email allow list (opens in new tab)</a>
+            text: "For a list of approved domains, see the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list">Care Identity email allow list (opens in new tab)</a>."
           },
           "id": "email",
           "name": "email",
@@ -98,7 +98,7 @@
             }
           },
           hint: {
-            text: "Only registered clinicians can assess the patient and record their consent"
+            text: "Only registered clinicians can assess the patient and record their consent."
           },
           "items": [
             {


### PR DESCRIPTION
Changed email address label from 'NHS email address' to 'NHS-approved email address'. 

Added text below the H1 to flag that you can only add users with an NHS-approved email address, plus link to the list of approved domains.

<img width="437" alt="image" src="https://github.com/user-attachments/assets/073a0ed7-2271-4c75-b561-f823a3bc1d9b" />

