### PR TITLE
Fix page titles

### DIFF
--- a/app/views/accessibility-statement.html
+++ b/app/views/accessibility-statement.html
@@ -1,15 +1,13 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Accessibility statement
-{% endblock %}
+{% set pageName = "Accessibility statement" %}
 
 {% block content %}
   <div class="nhsuk-grid-row">
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Accessibility statement</h1>
+      <h1>{{ pageName }}</h1>
 
         <p>This accessibility statement applies to the Record a vaccination service
             (<a href="https://www.ravs.england.nhs.uk">www.ravs.england.nhs.uk</a>)</p>
@@ -37,7 +35,7 @@
 
 
     <h2>Enforcement procedure</h2>
-    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p> 
+    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).</p>
     <p>If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support Service (EASS)</a>.</p>
 
     <h2>Technical information about this website’s accessibility</h2>

--- a/app/views/alerts/deactivated.html
+++ b/app/views/alerts/deactivated.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Record a vaccination
-{% endblock %}
+{% set pageName = "Organisation name has been deactivated" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}
@@ -20,14 +18,14 @@
             <h1 class="nhsuk-panel__title" style="color:#212b32;">
             Organisation name has been deactivated
             </h1>
-          
+
             <div class="nhsuk-panel__body" style="color:#212b32;">
             <p>This means you can no longer record vaccinations for this organisation.</p>
             <p>Until [date] you will still be able to access other parts of the Record a vaccination service.</p>
             <p>After [date] you will no longer have access to the service for ((Organisation name)).</p>
             </div>
 
-                    
+
             <br><br>
 
 
@@ -41,7 +39,7 @@
 
           </div>
 
-        
+
 
 
 

--- a/app/views/alerts/high-alert.html
+++ b/app/views/alerts/high-alert.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Record a vaccination
-{% endblock %}
+{% set pageName = "New section to record vaccinations" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}
@@ -20,16 +18,16 @@
             <h1 class="nhsuk-panel__title" style="color:#212b32;">
               New section to record vaccinations
             </h1>
-          
+
             <div class="nhsuk-panel__body" style="color:#212b32;">
-                We've updated the user journey for recording vaccinations. From now on, select 'Record vaccinations' from the header to start recording a vaccination. 
+                We've updated the user journey for recording vaccinations. From now on, select 'Record vaccinations' from the header to start recording a vaccination.
             </div>
 
             <br>
 
             <a href="/updates" style="color:#005eb8;">Example link</a>
-            
-            
+
+
             <br><br>
 
 
@@ -43,7 +41,7 @@
 
           </div>
 
-        
+
 
 
 

--- a/app/views/alerts/inset-2.html
+++ b/app/views/alerts/inset-2.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {{ currentOrganisation.name }} – Home
-{% endblock %}
+{% set pageName = currentOrganisation.name + " - Home" %}
 
 {% set currentSection = "home" %}
 
@@ -33,9 +31,9 @@
       <p>You have not yet recorded a vaccination.</p>
 
       <p class="nhsuk-body"><a href="/vaccines/choose-site">Add vaccines</a></p>
-  
+
       <p class="nhsuk-body"><a href="/user-admin/add-user">Add users</a></p>
-      
+
       <p class="nhsuk-body"><a href="/find-a-patient">Find a patient</a></p>
 
       <p>Find help and guidance at <a href="/reports">guide.ravs.england.nhs.uk</a></p>
@@ -85,7 +83,7 @@
     </li>
 
 </ul>
-    
+
 
     </div>
   </div>

--- a/app/views/alerts/new.html
+++ b/app/views/alerts/new.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Add batch" %}
 
 {% set currentSection = "vaccines" %}
 
@@ -17,7 +15,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Add batch</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <form action="/vaccines/check" method="post" novalidate="true">
 
@@ -59,7 +57,7 @@
 
           {{ radios({
             "idPrefix": "pack-type",
-            
+
             "name": "packType",
             "fieldset": {
               "legend": {
@@ -81,7 +79,7 @@
             ]
           }) }}
 
-        
+
 
           {{ button({
             "text": "Continue"

--- a/app/views/alerts/notification.html
+++ b/app/views/alerts/notification.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = "Vaccines" %}
 
 {% set currentSection = "vaccines" %}
 
@@ -19,7 +17,7 @@
 
       {% include "_test.html" %}
 
-      <h1 class="nhsuk-heading-xl">Vaccines</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <p class="nhsuk-body-l">Add and edit your vaccines for your organisation.</p>
 

--- a/app/views/button-states.html
+++ b/app/views/button-states.html
@@ -1,14 +1,12 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Button states
-{% endblock %}
+{% set pageName = "Button states" %}
 
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Button states</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
 
       <h2 class="nhsuk-heading-m">Not yet pressed</h2>

--- a/app/views/contact-us.html
+++ b/app/views/contact-us.html
@@ -1,14 +1,13 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Contact us
-{% endblock %}
+{% set pageName = "Contact us" %}
+
 
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Contact us</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <p>Telephone: <b>0121 611 0187</b> (select option 3)<br>
       Email: <a href="#">ravs.support@england.nhs.uk</a></p>

--- a/app/views/email-invite.html
+++ b/app/views/email-invite.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  RAVS (Record a vaccination service) Get started
-{% endblock %}
+{% set pageName = "RAVS (Record a vaccination service) Get started" %}
 
 {% block header %}
 {% endblock %}

--- a/app/views/home/index.html
+++ b/app/views/home/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {{ currentOrganisation.name }} – Home
-{% endblock %}
+{% set pageName = currentOrganisation.name + " - Home" %}
 
 {% set currentSection = "home" %}
 

--- a/app/views/home/site.html
+++ b/app/views/home/site.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {{ site.name }} - {{ currentOrganisation.name }} – Home
-{% endblock %}
+{% set pageName = currentOrganisation.name + " - Home" %}
 
 {% set currentSection = "home" %}
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -11,9 +11,8 @@
 -->
 
 <!-- Set the page title -->
-{% block pageTitle %}
-  NHS Record a vaccination prototypes
-{% endblock %}
+{% set pageName = "NHS Record a vaccination prototypes" %}
+
 
 <!-- For adding a breadcrumb or back link -->
 -->

--- a/app/views/okta-account-created.html
+++ b/app/views/okta-account-created.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Manage users and permissions
-{% endblock %}
+{% set pageName = "Manage users and permissions" %}
 
 {% block header %}
 {% endblock %}

--- a/app/views/okta-email.html
+++ b/app/views/okta-email.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Email inbox" %}
 
 {% block header %}
 {% endblock %}

--- a/app/views/okta-set-password.html
+++ b/app/views/okta-set-password.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Manage users and permissions
-{% endblock %}
+{% set pageName = "Manage users and permissions" %}
 
 {% block header %}
 {% endblock %}

--- a/app/views/okta-sign-in.html
+++ b/app/views/okta-sign-in.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Sign in
-{% endblock %}
+{% set pageName = "Sign in" %}
+
 
 {% block header %}
 {% endblock %}

--- a/app/views/product-page.html
+++ b/app/views/product-page.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  NHS Record a vaccination
-{% endblock %}
+{% set pageName = "" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}

--- a/app/views/prototype-admin/reset-data.html
+++ b/app/views/prototype-admin/reset-data.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Reset data
-{% endblock %}
+{% set pageName = "Reset data" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}

--- a/app/views/record-vaccinations/add-batch.html
+++ b/app/views/record-vaccinations/add-batch.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add a batch
-{% endblock %}
+{% set pageName = "Add a batch" %}
 
 {% set currentSection = "vaccines" %}
 
@@ -24,7 +22,7 @@
       }) }}
     {% endif %}
 
-      <h1 class="nhsuks-heading-l">Add a batch</h1>
+      <h1 class="nhsuks-heading-l">{{ pageName }}</h1>
 
       <form action="/record-vaccinations/answer-add-batch" method="post" novalidate>
 

--- a/app/views/record-vaccinations/patient-deceased-stop.html
+++ b/app/views/record-vaccinations/patient-deceased-stop.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Pateint deceased
-{% endblock %}
+{% set pageName = "Patient deceased" %}
+
 
 {% set currentSection = "vaccinate" %}
 
@@ -25,15 +24,15 @@
           <dd class="nhsuk-summary-list__value">
             Jodie Brown
           </dd>
-      
+
           <dd class="nhsuk-summary-list__actions">
-      
-      
-      
+
+
+
           </dd>
-      
+
         </div>
-      
+
 
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
@@ -42,10 +41,10 @@
           <dd class="nhsuk-summary-list__value">
             9123456789
           </dd>
-      
+
           <dd class="nhsuk-summary-list__actions">
           </dd>
-      
+
         </div>
 
         <div class="nhsuk-summary-list__row">
@@ -55,11 +54,11 @@
           <dd class="nhsuk-summary-list__value">
             15 March 1984
           </dd>
-      
+
           <dd class="nhsuk-summary-list__actions">
 
           </dd>
-      
+
         </div>
 
         <div class="nhsuk-summary-list__row">
@@ -69,16 +68,16 @@
           <dd class="nhsuk-summary-list__value">
             20 April 2024 <br> (40 years old)
           </dd>
-      
+
           <dd class="nhsuk-summary-list__actions">
 
           </dd>
-      
+
         </div>
-       
-       
-     
-      
+
+
+
+
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">
             Address
@@ -86,13 +85,13 @@
           <dd class="nhsuk-summary-list__value">
             73 Roman Rd<br>Leeds<br> LS2 5ZN
           </dd>
-      
+
           <dd class="nhsuk-summary-list__actions">
           </dd>
-      
+
         </div>
-      
-    
+
+
 
     </div>
   </div>

--- a/app/views/regions/add-another-email-check.html
+++ b/app/views/regions/add-another-email-check.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Check and send" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -18,7 +16,7 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1 class="nhsuk-heading-xl">Check and send</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <p>This email will be sent to {{ data["email"] }}:</p>
 

--- a/app/views/regions/add-another-email.html
+++ b/app/views/regions/add-another-email.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add another user
-{% endblock %}
+{% set pageName = "Add another user" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -19,14 +17,14 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Add another user</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p>Choose another user at {{ organisation.name }}.</p>
-        
+
       <p>They must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">list of approved email domains (opens in new tab)</a>.</p>
-      
+
       <p>They will receive an email with details of how to access the service.</p>
-      
+
       <p>It's their responsibility to add users and set up vaccination sites for their organisation.</p>
 
       <form action="/regions/organisations/{{ organisation.id }}/add-email-check" method="post" novalidate>

--- a/app/views/regions/add-email.html
+++ b/app/views/regions/add-email.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Add a user" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -20,12 +18,12 @@
     <div class="nhsuk-grid-column-two-thirds">
 
 
-      <h1 class="nhsuk-heading-l">Add a user</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p>Choose a user at {{ organisation.name }}.</p>
-      
+
       <p>They must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank">list of approved email domains (opens in new tab)</a>.</p>
-      
+
       <p>They will receive an email with details of how to access the service.</p>
 
       <p>It’s their responsibility to add users and set up vaccination sites for their organisation.</p>

--- a/app/views/regions/add-organisation.html
+++ b/app/views/regions/add-organisation.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Find an organisation to invite" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -20,7 +18,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
 
-      <h1 class="nhsuk-heading-xl">Find an organisation to invite</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <form action="/regions/organisation-details" method="post">
 

--- a/app/views/regions/add-organisation1.html
+++ b/app/views/regions/add-organisation1.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Find an organisation to invite" %}
+
 
 {% block header %}
   {% include "includes/header-logged-in-region1.html" %}
@@ -15,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
 
-      <h1 class="nhsuk-heading-xl">Find an organisation to invite</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <form action="/regions/organisation-details" method="post">
 

--- a/app/views/regions/awaiting-approval1.html
+++ b/app/views/regions/awaiting-approval1.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England region
-{% endblock %}
+{% set pageName = "Waiting for approval" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region1.html" %}
@@ -14,14 +12,14 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Waiting for approval</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
     </div>
   </div>
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-full">
 
-        
+
 
         <table role="table" class="nhsuk-table-responsive">
             <thead role="rowgroup" class="nhsuk-table__head">
@@ -39,12 +37,12 @@
                    Date requested
                 </th>
                 <th role="columnheader" class="" scope="col">
-                    
+
                  </th>
                  <th role="columnheader" class="" scope="col">
-                    
+
                  </th>
-              
+
                 </tr>
               </thead>
               <tbody class="nhsuk-table__body">
@@ -59,7 +57,7 @@
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>NHS Trust
                   </td>
                   <td role="cell" class="nhsuk-table__cell">
-                      <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>4 April 2025 
+                      <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>4 April 2025
                     </td>
                     <td role="cell" class="nhsuk-table__cell">
                       <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/accept">Approve</a>
@@ -67,7 +65,7 @@
                     <td role="cell" class="nhsuk-table__cell">
                       <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/reject">Reject</a>
                     </td>
-              
+
                 </tr>
             </thead>
             <tbody class="nhsuk-table__body">
@@ -82,7 +80,7 @@
                   <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>NHS Trust
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>3 April 2025 
+                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>3 April 2025
                   </td>
                   <td role="cell" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/accept">Approve</a>
@@ -91,7 +89,7 @@
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/reject">Reject</a>
                   </td>
 
-                  
+
 
               </tr>
               <tr role="row" class="nhsuk-table__row">
@@ -105,7 +103,7 @@
                   <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>NHS Trust
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>1 April 2025 
+                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>1 April 2025
                   </td>
                   <td role="cell" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/accept">Approve</a>
@@ -122,10 +120,10 @@
                   <span class="nhsuk-table-responsive__heading" aria-hidden="true">ODS code</span>PP34
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                  <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>Community Pharmacy 
+                  <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>Community Pharmacy
                 </td>
                 <td role="cell" class="nhsuk-table__cell">
-                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>28 March 2025 
+                    <span class="nhsuk-table-responsive__heading" aria-hidden="true">Date requested</span>28 March 2025
                   </td>
                   <td role="cell" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/accept">Approve</a>
@@ -133,7 +131,7 @@
                   <td role="cell" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Organisation </span><a href="/regions/reject">Reject</a>
                   </td>
-              
+
             </tbody>
           </table>
 

--- a/app/views/regions/check-and-send.html
+++ b/app/views/regions/check-and-send.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Check and send" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -19,7 +17,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Check and send</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       {{ summaryList({
         rows: [

--- a/app/views/regions/deactivate.html
+++ b/app/views/regions/deactivate.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Deactivate " + organisation.name %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}
@@ -19,7 +17,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Deactivate {{organisation.name}}</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p>Once this organisation has been deactivated, users will no longer be able to record vaccinations.</p>
 

--- a/app/views/regions/index1.html
+++ b/app/views/regions/index1.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England region
-{% endblock %}
+{% set pageName = "North West Commissioning Region" %}
+
 
 {% block header %}
   {% include "includes/header-logged-in-region1.html" %}
@@ -14,16 +13,16 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <span class="nhsuk-caption-m">North West Commisioning Region</span>
+      <span class="nhsuk-caption-m">{{ pageName }}</span>
       <h1 class="nhsuk-heading-xl">Organisations</h1>
-      
+
 
     </div>
 </div>
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      
+
 
       <table role="table" class="nhsuk-table-responsive">
           <thead role="rowgroup" class="nhsuk-table__head">
@@ -40,7 +39,7 @@
               <th role="columnheader" class="" scope="col">
                  Status
               </th>
-              
+
               </tr>
             </thead>
             <tbody class="nhsuk-table__body">
@@ -57,7 +56,7 @@
                 <td role="cell" class="nhsuk-table__cell">
                     <span class="nhsuk-table-responsive__heading" aria-hidden="true">Status</span>Active
                   </td>
-            
+
               </tr>
           </thead>
           <tbody class="nhsuk-table__body">
@@ -75,7 +74,7 @@
                 <span class="nhsuk-table-responsive__heading" aria-hidden="true">Status</span>Active
               </td>
 
-                
+
 
             </tr>
             <tr role="row" class="nhsuk-table__row">
@@ -100,12 +99,12 @@
                 <span class="nhsuk-table-responsive__heading" aria-hidden="true">ODS code</span>PP34
               </td>
               <td role="cell" class="nhsuk-table__cell">
-                <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>Community Pharmacy 
+                <span class="nhsuk-table-responsive__heading" aria-hidden="true">Type</span>Community Pharmacy
               </td>
               <td role="cell" class="nhsuk-table__cell">
                 <span class="nhsuk-table-responsive__heading" aria-hidden="true">Status</span>Active
               </td>
-            
+
           </tbody>
         </table>
 

--- a/app/views/regions/organisation-details.html
+++ b/app/views/regions/organisation-details.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Organisation" %}
+
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}

--- a/app/views/regions/organisation.html
+++ b/app/views/regions/organisation.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {{ organisation.name }}
-{% endblock %}
+{% set pageName = organisation.name %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}

--- a/app/views/regions/reactivate.html
+++ b/app/views/regions/reactivate.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Reactivate Anderson Road Pharmacy" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}

--- a/app/views/regions/uninvite.html
+++ b/app/views/regions/uninvite.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Uninvite {{ user.firstName }} {{ user.lastName }}
-{% endblock %}
+{% set pageName = "Uninvite" %}
 
 {% block header %}
   {% include "includes/header-logged-in-region.html" %}

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Check and confirm
-{% endblock %}
+{% set pageName = "Check and confirm" %}
 
 {% set currentSection = "reports" %}
 
@@ -19,7 +17,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Check and confirm</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       {{ summaryList({
         rows: [

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose data
-{% endblock %}
+{% set pageName = "Choose data" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose dates
-{% endblock %}
+{% set pageName = "Choose dates" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose sites
-{% endblock %}
+{% set pageName = "Choose sites" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose vaccines
-{% endblock %}
+{% set pageName = "Choose vaccines" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/download.html
+++ b/app/views/reports/download.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Report is ready
-{% endblock %}
+{% set pageName = "Report is ready" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Reports
-{% endblock %}
+{% set pageName = "Reports" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/select-organisation.html
+++ b/app/views/select-organisation.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Sign in
-{% endblock %}
+{% set pageName = "Sign in" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}

--- a/app/views/sign-in.html
+++ b/app/views/sign-in.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Record a vaccination
-{% endblock %}
+{% set pageName = "" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}

--- a/app/views/support/index.html
+++ b/app/views/support/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Stats
-{% endblock %}
+{% set pageName = "Dashboard" %}
 
 {% set currentSection = "dashboard" %}
 

--- a/app/views/support/users/edit-organisation.html
+++ b/app/views/support/users/edit-organisation.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Edit user permissions
-{% endblock %}
+{% set pageName = "Edit user permissions" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/app/views/support/users/edit-region.html
+++ b/app/views/support/users/edit-region.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Edit user permissions
-{% endblock %}
+{% set pageName = "User" %}
 
 {% block beforeContent %}
   {{ backLink({

--- a/app/views/terms-of-use.html
+++ b/app/views/terms-of-use.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Agree to the terms of use
-{% endblock %}
+{% set pageName = "Agree to the terms of use" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}
@@ -13,7 +11,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Agree to the terms of use</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <ul class="nhsuk-list nhsuk-list--bullet">
         <li>Only use the service to record NHS vaccinations.</li>

--- a/app/views/terms-of-use1.html
+++ b/app/views/terms-of-use1.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Terms of use
-{% endblock %}
+{% set pageName = "Terms of use" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}
@@ -12,7 +10,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Terms of use</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <h2 class="nhsuk-heading-m">1. Introduction</h2>
 

--- a/app/views/updates/dec_24.html
+++ b/app/views/updates/dec_24.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -18,8 +16,8 @@ Updates
       <h1 class="nhsuk-heading-l">December 2024</h1>
       <p class="nhsuk-body-l">This pages lists updates made to the Record a vaccination service in December 2024.</p>
 
-           
-     
+
+
 
 
 

--- a/app/views/updates/feb_25.html
+++ b/app/views/updates/feb_25.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -20,8 +18,8 @@ Updates
       <h1 class="nhsuk-heading-l">February 2025</h1>
       <p class="nhsuk-body-l">This pages lists updates made to the Record a vaccination service in February 2025.</p>
 
-           
-     
+
+
 
 
 

--- a/app/views/updates/future.html
+++ b/app/views/updates/future.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -35,7 +33,7 @@ Updates
           </li>
         </ol>
       </nav>
-   
+
 
 
     </div>

--- a/app/views/updates/index.html
+++ b/app/views/updates/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -11,8 +9,8 @@ Updates
     <div class="nhsuk-grid-column-full">
 
       <h1 class="nhsuk-heading-l">Updates</h1>
-      
-      
+
+
       <br>
       <p class="nhsuk-body-l"><a href="/updates/previous" class="nhsuk-link">Previous updates</a></p>
       <p class="nhsuk-body-l"><a href="/updates/future" class="nhsuk-link">Future updates</a></p>

--- a/app/views/updates/jan_25.html
+++ b/app/views/updates/jan_25.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -19,8 +17,8 @@ Updates
       <h1 class="nhsuk-heading-l">January 2025</h1>
       <p class="nhsuk-body-l">This pages lists updates made to the Record a vaccination service in January 2025.</p>
 
-           
-     
+
+
 
 
 

--- a/app/views/updates/multiple.html
+++ b/app/views/updates/multiple.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = "Vaccines" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/updates/nov_24.html
+++ b/app/views/updates/nov_24.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -18,8 +16,8 @@ Updates
       <h1 class="nhsuk-heading-l">November 2024</h1>
       <p class="nhsuk-body-l">This pages lists updates made to the Record a vaccination service in November 2024.</p>
 
-           
-     
+
+
 
 
 

--- a/app/views/updates/previous.html
+++ b/app/views/updates/previous.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-Updates
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% set currentSection = "updates" %}
 
@@ -35,7 +33,7 @@ Updates
           </li>
         </ol>
       </nav>
-   
+
 
 
     </div>

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add user
-{% endblock %}
+{% set pageName = "Add user" %}
 
 {% set currentSection = "manage-users" %}
 

--- a/app/views/user-admin/change.html
+++ b/app/views/user-admin/change.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add user
-{% endblock %}
+{% set pageName = "Add user" %}
 
 {% set currentSection = "manage-users" %}
 

--- a/app/views/user-admin/check.html
+++ b/app/views/user-admin/check.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  East of England
-{% endblock %}
+{% set pageName = "Check" %}
 
 {% set currentSection = "manage-users" %}
 

--- a/app/views/user-admin/deactivate.html
+++ b/app/views/user-admin/deactivate.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add user
-{% endblock %}
+{% set pageName = "Deactivate your account" %}
 
 {% set currentSection = "manage-users" %}
 
@@ -19,7 +17,7 @@
 
       {% if user.id === currentUser.id %}
 
-        <h1 class="nhsuk-heading-l">Deactivate your account</h1>
+        <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
         <p>Once you deactivate your account, you’ll be signed out and cannot sign in and use NHS Record a vaccination.</p>
 

--- a/app/views/user-admin/deactivated.html
+++ b/app/views/user-admin/deactivated.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Manage users and permissions
-{% endblock %}
+{% set pageName = "Deactivated users" %}
 
 {% set currentSection = "manage-users" %}
 

--- a/app/views/user-admin/index.html
+++ b/app/views/user-admin/index.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Manage users and permissions
-{% endblock %}
+{% set pageName = "Manage users" %}
+
 
 {% from '../../components/pagination/macro.njk' import appPagination %}
 
@@ -12,7 +11,7 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      <h1 class="nhsuk-heading-xl">Manage users</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       {{ button({
         "text": "Add user",

--- a/app/views/user-admin/reactivate.html
+++ b/app/views/user-admin/reactivate.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add user
-{% endblock %}
+{% set pageName = "Reactivate user" %}
+
 
 {% set currentSection = "manage-users" %}
 

--- a/app/views/user-profile/index.html
+++ b/app/views/user-profile/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Your profile
-{% endblock %}
+{% set pageName = "Your profile" %}
 
 {% set currentSection = "user-profile" %}
 

--- a/app/views/user-profile/name.html
+++ b/app/views/user-profile/name.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Update your name
-{% endblock %}
+{% set pageName = "Update your name" %}
 
 {% set currentSection = "user-profile" %}
 

--- a/app/views/vaccines/add-batch-to-site-check.html
+++ b/app/views/vaccines/add-batch-to-site-check.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = "Check and confirm" %}
 
 {% set currentSection = "vaccines" %}
 {% set organisation = {name: data.nhsTrusts[data.organisationCode]} %}

--- a/app/views/vaccines/add-batch-to-site.html
+++ b/app/views/vaccines/add-batch-to-site.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Add batch" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Add batch" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/check.html
+++ b/app/views/vaccines/check.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = "Check and confirm" %}
 
 {% set currentSection = "vaccines" %}
 
@@ -12,7 +10,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Check and confirm</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
 
       {{ summaryList({

--- a/app/views/vaccines/choose-site.html
+++ b/app/views/vaccines/choose-site.html
@@ -1,8 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose site
-{% endblock %}
+{% set pageName = "Site" %}
+
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/choose-vaccine.html
+++ b/app/views/vaccines/choose-vaccine.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Choose vaccine
-{% endblock %}
+{% set pageName = "Choose vaccine" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/deplete-batch.html
+++ b/app/views/vaccines/deplete-batch.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Deplete batch" %}
 
 {% set currentSection = "vaccines" %}
 
@@ -14,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuks-heading-l">Deplete batch</h1>
+      <h1 class="nhsuks-heading-l">{{ pageName }}</h1>
 
       {{ summaryList({
         rows: [

--- a/app/views/vaccines/edit-batch.html
+++ b/app/views/vaccines/edit-batch.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Edit batch" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = "Vaccines" %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/product-page.html
+++ b/app/views/vaccines/product-page.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Vaccines
-{% endblock %}
+{% set pageName = vaccine.vaccineProduct %}
 
 {% set currentSection = "vaccines" %}
 

--- a/app/views/vaccines/reactivate.html
+++ b/app/views/vaccines/reactivate.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Add batch
-{% endblock %}
+{% set pageName = "Reactivate batch " + batch.batchNumber %}
 
 {% set currentSection = "vaccines" %}
 
@@ -14,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuks-heading-l">Reactivate batch {{ batch.batchNumber }}</h1>
+      <h1 class="nhsuks-heading-l">{{ pageName }}</h1>
 
       <p>This batch will become ‘active’ immediately.</p>
 


### PR DESCRIPTION
This switches to using `{% set pageName %}` on all pages instead of `{% block pageTitle %}`, so that the service name is appended as `<title>{{ pageName %}} - NHS Record a vaccinations</title>`.