### PR TITLE
Add clinician status to onboarding flow

### DIFF
--- a/app/routes/apply.js
+++ b/app/routes/apply.js
@@ -41,6 +41,7 @@ module.exports = router => {
     data.firstName = null
     data.lastName = null
     data.email = null
+    data.clinician = null
 
     res.redirect(nextPage)
   })

--- a/app/views/apply/check.html
+++ b/app/views/apply/check.html
@@ -90,6 +90,23 @@
                 }
               ]
             }
+          },
+          {
+            key: {
+              text: "Clinical"
+            },
+            value: {
+              text: ("Yes" if data.clinician == "yes" else "No")
+            },
+            actions: {
+              items: [
+                {
+                  href: "/apply/contact-details",
+                  text: "Change",
+                  visuallyHiddenText: "clinician status"
+                }
+              ]
+            }
           }
         ]
       }) }}

--- a/app/views/apply/contact-details.html
+++ b/app/views/apply/contact-details.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Your contact details" %}
+{% set pageName = "Your details" %}
 
 {% block header %}
   {% include "includes/header-logged-out.html" %}
@@ -61,6 +61,30 @@
             "text": emailError
           } if emailError
         }) }}
+
+        {{ radios({
+          name: "clinician",
+          fieldset: {
+            legend: {
+              text: "Are you a registered clinician?"
+            }
+          },
+          hint: {
+            text: "Only registered clinicians can be recorded as the vaccinator."
+          },
+          value: data.clinician,
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ]
+        }) }}
+
 
         {{ button({
           "text": "Continue"


### PR DESCRIPTION
We can ask users if they are a registered clinician when signing up, to save them having to set this later (which some users have not realised they need to do).

![localhost_3002_apply_contact-details (1)](https://github.com/user-attachments/assets/f6617462-123e-4d5c-9854-f8ebfa56b3db)
