### PR TITLE
Add warning to patient vaccination history

### DIFF
--- a/app/views/record-vaccinations/patient-history.html
+++ b/app/views/record-vaccinations/patient-history.html
@@ -89,6 +89,11 @@
       <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, pertussis and RSV.</p>
 
       <p>However, pertussis vaccinations given at a GP surgery are not shown.</p>
+
+      {{ warningCallout({
+        heading: "Important",
+        html: "<p>Some RSV vaccination records entered by GPs are incorrect and the patient may not yet have had their vaccination.</p><p>Check with the patient or their GP.</p>"
+      }) }}
     </div>
   </div>
   <div class="nhsuk-grid-row">


### PR DESCRIPTION
This adds a warning to the patient vaccination history about an issue affecting RSV vaccination records.

We’d remove this in future once the issue has been resolved.

## Screenshot

![Screenshot 2025-06-16 at 10 54 13](https://github.com/user-attachments/assets/092b5346-cbac-4af7-886d-48ee745f9dbb)
