### PR TITLE
Update reveal text on vaccinator screen

### DIFF
--- a/app/views/record-vaccinations/vaccinator.html
+++ b/app/views/record-vaccinations/vaccinator.html
@@ -78,12 +78,12 @@
       {% if organisationSetting.permissionLevel == "Lead administrator" %}
         {{ details({
           text: "If the vaccinator is not listed",
-          html: "Make sure they are added in <a href=\"/user-admin\">Manage users</a> as a clinician."
+          html: "Make sure they are added in <a href=\"/user-admin\">Manage users</a> as a vaccinator."
         }) }}
       {% else %}
         {{ details({
           text: "If the vaccinator is not listed",
-          html: ">If the vaccinator is not listed, ask a lead administrator to make sure they are added as a clinician."
+          html: "You'll need to ask a lead administrator to add them."
         }) }}
 
       {% endif %}


### PR DESCRIPTION
Changed reveal text as mention of clinician status is no longer relevant, following changes to Manage users.