### PR TITLE
Allow regions to only add vaccines to orgs, not remove

### DIFF
--- a/app/routes/regions.js
+++ b/app/routes/regions.js
@@ -267,18 +267,18 @@ module.exports = router => {
   })
 
   // Viewing the page to set vaccines per organisation
-  router.get('/regions/organisations/:id/change-vaccines', (req, res) => {
+  router.get('/regions/organisations/:id/add-vaccines', (req, res) => {
     const data = req.session.data
     const id = req.params.id
     const organisation = data.organisations.find((org) => org.id === id)
     if (!organisation) { res.redirect('/regions/'); return }
 
     const vaccines = organisation.vaccines || []
-    const vaccinesEnabled = vaccines.filter((vaccine) => vaccine.status === "enabled")
+    const vaccinesNotYetAdded = vaccines.filter((vaccine) => vaccine.status !== "enabled")
 
-    res.render('regions/change-vaccines', {
+    res.render('regions/add-vaccines', {
       organisation,
-      vaccinesEnabled
+      vaccinesNotYetAdded
     })
   })
 
@@ -289,12 +289,14 @@ module.exports = router => {
     const organisation = data.organisations.find((org) => org.id === id)
     if (!organisation) { res.redirect('/regions/'); return }
 
-    const vaccinesEnabled = data.vaccinesEnabled
+    const vaccinesToAdd = data.vaccinesToAdd
 
     const vaccines = organisation.vaccines || []
 
     for (vaccine of vaccines) {
-      vaccine.status = (vaccinesEnabled.includes(vaccine.name) ? "enabled" : "disabled")
+      if (vaccinesToAdd.includes(vaccine.name)) {
+        vaccine.status = "enabled"
+      }
     }
 
     res.redirect(`/regions/organisations/${id}`)

--- a/app/views/regions/add-vaccines.html
+++ b/app/views/regions/add-vaccines.html
@@ -24,7 +24,7 @@
 
         {% set items = [] %}
 
-        {% for vaccine in (organisation.vaccines | sort(false, false, "name")) %}
+        {% for vaccine in (vaccinesNotYetAdded) %}
           {% set items = (items.push({
             value: vaccine.name,
             text: (vaccine.name | capitaliseFirstLetter)
@@ -32,21 +32,20 @@
         {% endfor %}
 
         {{ checkboxes({
-          name: "vaccinesEnabled",
+          name: "vaccinesToAdd",
           classes: "nhsuk-radios--inline",
           fieldset: {
             legend: {
-              text: "Which vaccinations can they record?",
+              text: "Which vaccines would you like give them access to?",
               classes: "nhsuk-fieldset__legend--l",
               isPageHeading: true
             }
           },
-          values: (vaccinesEnabled | pluck("name")),
           items: items
         }) }}
 
         {{ button({
-          text: "Save"
+          text: "Confirm"
         }) }}
       </form>
 

--- a/app/views/regions/add-vaccines.html
+++ b/app/views/regions/add-vaccines.html
@@ -36,7 +36,7 @@
           classes: "nhsuk-radios--inline",
           fieldset: {
             legend: {
-              text: "Which vaccines would you like give them access to?",
+              text: "Which vaccines do you want to add?",
               classes: "nhsuk-fieldset__legend--l",
               isPageHeading: true
             }

--- a/app/views/regions/organisation.html
+++ b/app/views/regions/organisation.html
@@ -37,7 +37,10 @@
             {{ vaccinesEnabled | sort(false, false, "name") | pluck("name") | formatList }}
           {% endif %}
         vaccinations.
-          <a href="/regions/organisations/{{organisation.id}}/change-vaccines">Change <span class="nhsuk-u-visually-hidden">vaccines available</span></a>
+
+          {% if (vaccinesEnabled | length) < 4 %}
+            <a href="/regions/organisations/{{organisation.id}}/add-vaccines">Add vaccines<span class="nhsuk-u-visually-hidden"></span></a>
+          {% endif %}
         </p>
 
         {% if (messages | length) > 0 %}


### PR DESCRIPTION
This updates the design done in #365 to make a small change in that we’ve decided to only allow regions to _add_ the ability for organisations to record individual vaccine types, but not to _remove_ access.

This is because:

* an organisation might need to edit (or correct by deleting and re-adding) a record for a vaccine even if they're no longer giving it
* organisations are able to add records retrospectively if needed
* we don’t want to encourage regions to unnecessarily remove access to vaccines 'out of season' (ie in the summer) when an organisation is likely to need access again in the winter

## Screenshots

| Before | After |
| -------|-------|
| ![Screenshot 2025-07-03 at 14 47 46](https://github.com/user-attachments/assets/3c972b1a-155d-4131-99b0-417552f79c1d) | ![Screenshot 2025-07-03 at 14 47 27](https://github.com/user-attachments/assets/8274ef39-8348-46c2-951f-d135469496e3) |
| ![Screenshot 2025-07-03 at 14 48 21](https://github.com/user-attachments/assets/18e1ea51-63a9-4737-848f-b4d323514a68) | ![Screenshot 2025-07-03 at 14 48 39](https://github.com/user-attachments/assets/1104400b-a5dd-4aec-8917-41f70390ed8c) |
| ![Screenshot 2025-07-03 at 14 49 27](https://github.com/user-attachments/assets/8d06025a-c360-44ee-8a22-ab4d6287ef8b) | ![Screenshot 2025-07-03 at 16 18 00](https://github.com/user-attachments/assets/54a01ef2-c287-4149-ab03-a0cd36726092) |
