### PR TITLE
Locations screen updates for flu for winter 2025-2026

### DIFF
--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -562,17 +562,16 @@ module.exports = router => {
         nextPage = "/record-vaccinations/patient-history"
       }
 
-    } else {
-
-      if ((data.vaccine === "COVID-19") || (data.vaccine == "flu")) {
-        if (data.eligibility === "Healthcare worker" || data.eligibility.includes("Healthcare worker")) {
-          nextPage = "/record-vaccinations/healthcare-worker"
-        } else {
-          nextPage = "/record-vaccinations/location"
-        }
+    } else if (data.vaccine == "flu") {
+      if (data.eligibility === "Healthcare worker") {
+        nextPage = "/record-vaccinations/healthcare-worker"
       } else {
         nextPage = "/record-vaccinations/patient"
       }
+    } else if (data.vaccine == "COVID-19") {
+      nextPage = "/record-vaccinations/location"
+    } else {
+      nextPage = "/record-vaccinations/patient"
     }
 
     res.redirect(nextPage)

--- a/app/views/record-vaccinations/location.html
+++ b/app/views/record-vaccinations/location.html
@@ -20,12 +20,7 @@
       {% endif %}
 
       <form action="/record-vaccinations/answer-location" method="post" novalidate>
-
-        {% from 'radios/macro.njk' import radios %}
-        {% from 'input/macro.njk' import input %}
-
         {% set careHtml %}
-
 
         <div class="nhsuk-form-group">
           <label class="nhsuk-label nhsuk-label--s" for="care-home">
@@ -53,8 +48,6 @@
 
           </select>
         </div>
-
-
       {% endset -%}
 
         {{ radios({
@@ -70,44 +63,26 @@
           hint: {
             text: "This is needed for payment and reporting."
           },
+          value: data.locationType,
           items: [
             {
-              text: "Hospital hub for staff and patients",
-              value: "Hospital hub for staff and patients",
-              checked: (data.locationType === "Hospital hub for staff and patients")
-            },
-            {
-              text: "Vaccination centre open to the public",
-              value: "Vaccination centre open to the public",
-              checked: (data.locationType === "Vaccination centre open to the public")
-            },
-            {
-              text: "Community pharmacy",
-              value: "Community pharmacy",
-              checked: (data.locationType === "Community pharmacy")
+              text: "On site",
+              value: "On site"
             },
             {
               value: "Care home",
               text: "Care home",
-              checked: (data.locationType === "Care home"),
               conditional: {
                 html: careHtml
               }
             },
             {
               text: "Housebound patient’s home",
-              value: "Housebound patient’s home",
-              checked: (data.locationType === "Housebound patient’s home")
+              value: "Housebound patient’s home"
             },
             {
               text: "Outreach event",
-              value: "Outreach event",
-              checked: (data.locationType === "Outreach event")
-            },
-            {
-              text: "GP clinic",
-              value: "GP clinic",
-              checked: (data.locationType === "GP clinic")
+              value: "Outreach event"
             }
           ]
 


### PR DESCRIPTION
This updates the prototype so that:

* location is no longer asked for flu vaccinations
* for COVID-19 vaccinations, the number of options has been reduced to 4

## Screenshots for COVID-19

| Before | After |
|--------|-------|
| <img width="775" height="622" alt="Screenshot 2025-07-15 at 14 27 55" src="https://github.com/user-attachments/assets/459a32c3-e2d2-43ee-89a5-262b84bff926" /> | <img width="767" height="499" alt="Screenshot 2025-07-15 at 14 27 37" src="https://github.com/user-attachments/assets/a97b119c-da66-4a7e-8ad0-9daf7eaf1b0e" /> |
