### PR TITLE
Add an example of product name not known

### DIFF
--- a/app/views/record-vaccinations/patient-history.html
+++ b/app/views/record-vaccinations/patient-history.html
@@ -166,7 +166,8 @@
                 text: "Flu"
               },
               {
-                text: "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)"
+                text: "Not known",
+                classes: "nhsuk-u-secondary-text-color"
               }
             ],
             [


### PR DESCRIPTION
We do not always get a product name as part of the vaccination history (as it may not have been recorded).

In these scenarios, we’ve decided to show "Not known" in the secondary text colour (dark grey) rather than leave it blank. This is clearer and resolves a potential accessibility issue.

<img width="1020" height="469" alt="Screenshot 2025-07-15 at 18 14 10" src="https://github.com/user-attachments/assets/746314e2-8a06-4cdd-a8d3-06964e6c5d08" />
