### PR TITLE
Add more examples of other vaccines to patient history

### DIFF
--- a/app/views/record-vaccinations/patient-history.html
+++ b/app/views/record-vaccinations/patient-history.html
@@ -127,6 +127,16 @@
               }
             ],[
               {
+                text: "9 November 2024"
+              },
+              {
+                text: "MMR (second dose)"
+              },
+              {
+                text: "Priorix"
+              }
+            ],[
+              {
                 text: "11 November 2024"
               },
               {
@@ -134,6 +144,17 @@
               },
               {
                 text: "Abrysvo"
+              }
+            ],
+            [
+              {
+                text: "29 October 2024"
+              },
+              {
+                text: "Pneumococcal"
+              },
+              {
+                text: "Pneumovax"
               }
             ],
             [
@@ -172,6 +193,17 @@
             ],
             [
               {
+                text: "7 October 2023"
+              },
+              {
+                text: "Pertussis"
+              },
+              {
+                text: "Boostrix-IPV suspension"
+              }
+            ],
+            [
+              {
                 text: "11 March 2022"
               },
               {
@@ -179,6 +211,17 @@
               },
               {
                 text: "Moderna mRNA (Spikevax) Original"
+              }
+            ],
+            [
+              {
+                text: "4 December 2023"
+              },
+              {
+                text: "MMR (first dose)"
+              },
+              {
+                text: "Priorix"
               }
             ]
           ]


### PR DESCRIPTION
This adds examples of all 6 supported vaccines to the patient history.

For MMR, we could also display whether it is a first or second dose.

## Screenshot

<img width="1025" height="722" alt="Screenshot 2025-07-17 at 11 08 29" src="https://github.com/user-attachments/assets/6d864598-805f-42ca-990a-a45a43fe42be" />
