### PR TITLE
Add London flu service as a separate vaccine type

### DIFF
--- a/app/data/organisations.js
+++ b/app/data/organisations.js
@@ -715,7 +715,8 @@ module.exports = [
       {name: "RSV", status: "disabled"},
       {name: "COVID-19", status: "enabled"},
       {name: "pertussis", status: "disabled"},
-      {name: "flu", status: "enabled"}
+      {name: "flu", status: "enabled"},
+      {name: "flu (London Flu service)", status: "enabled"}
     ],
     sites: [
       {

--- a/app/data/vaccines.js
+++ b/app/data/vaccines.js
@@ -40,6 +40,29 @@ module.exports = [
     ]
   },
   {
+    name: "flu (London flu service)",
+    products: [
+      {
+        name: "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)"
+      },
+      {
+        name: "Cell-based Quadrivalent Influenza Vaccine (QIVc)"
+      },
+      {
+        name: "Fluenz (LAIV)"
+      },
+      {
+        name: "Influenza Tetra MYL (QIVe)"
+      },
+      {
+        name: "Quadrivalent Influenza Vaccine (QIVe)"
+      },
+      {
+        name: "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)"
+      }
+    ]
+  },
+  {
     name: "pertussis",
     products: [
       {

--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -769,7 +769,7 @@ module.exports = router => {
       redirectPath = "/record-vaccinations/add-batch"
     } else if (!vaccineBatch) {
       redirectPath = "/record-vaccinations/batch?showError=yes"
-    } else if (["COVID-19", "flu", "RSV", "pneumococcal"].includes(data.vaccine)) {
+    } else if (["COVID-19", "flu", "flu (London flu service)", "RSV", "pneumococcal"].includes(data.vaccine)) {
       redirectPath = "/record-vaccinations/eligibility"
     } else if (data.repeatPatient === "yes") {
       redirectPath = "/record-vaccinations/patient-estimated-due-date"

--- a/app/views/record-vaccinations/eligibility.html
+++ b/app/views/record-vaccinations/eligibility.html
@@ -76,6 +76,8 @@
           {% set eligibilityOptions = CovidEligibilityOptions %}
         {% elif data.vaccine == "flu" %}
           {% set eligibilityOptions = NationalFluEligibilityOptions %}
+        {% elif data.vaccine == "flu (London flu service)" %}
+          {% set eligibilityOptions = londonFluEligibilityOptions %}
         {% elif data.vaccine == "RSV" %}
           {% set eligibilityOptions = RSVEligibilityOptions %}
         {% elif data.vaccine == "pneumococcal" %}
@@ -99,39 +101,6 @@
             isPageHeading: true
           }
         }) %}
-
-          {% if data.vaccine == "flu" %}
-
-            {% set londonFluItems = [] %}
-            {% for option in londonFluEligibilityOptions %}
-              {% set londonFluItems = (londonFluItems.push({
-                text: option,
-                value: option
-                }), londonFluItems) %}
-            {% endfor %}
-
-            {% set londonFluHtml %}
-              {{ radios({
-                idPrefix: "eligibility-2",
-                name: "eligibility",
-                items: londonFluItems,
-                value: data.eligibility
-              }) }}
-            {% endset %}
-
-            {% set items = (items.push({
-              divider: "or"
-            }), items) %}
-
-            {% set items = (items.push({
-              text: "London flu service",
-              value: "london-flu",
-              conditional: {
-                html: londonFluHtml
-              }
-            }), items) %}
-
-          {% endif %}
 
           {% if data.vaccine == "pneumococcal" %}
             <h2 class="nhsuk-u-font-size-19 nhsuk-u-margin-bottom-2 nhsuk-u-margin-top-3 nhsuk-u-font-weight-normal">Aged 65 and over</h2>


### PR DESCRIPTION
As an alternative to #395, this adds the London flu service eligibility options by creating a separate vaccine type instead.

This would be technically simpler to develop, but would have the downside of requiring pharmacies to double enter all their flu vaccine batch numbers and expiry dates, as they use the same physical vaccines for both the National and London flu campaigns.

## Screenshots



|  | Before | After |
|--|--------|-------|
| Adding batch | <img width="511" height="282" alt="Screenshot 2025-07-21 at 12 06 02" src="https://github.com/user-attachments/assets/3ead6862-7491-48f8-bc2c-e40b6d0aea5f" /> | <img width="451" height="318" alt="Screenshot 2025-07-21 at 12 10 05" src="https://github.com/user-attachments/assets/2df65670-c27a-492f-a672-091c19bd2332" /> |
| Selecting vaccine when recording | <img width="707" height="474" alt="Screenshot 2025-07-21 at 12 04 56" src="https://github.com/user-attachments/assets/519747cd-27c3-44cd-9ee6-74587785babf" /> | <img width="755" height="533" alt="Screenshot 2025-07-21 at 12 05 22" src="https://github.com/user-attachments/assets/879e1682-6ffc-4623-8215-c16c6625aec0" /> |
| Eligibility | <img width="755" height="1101" alt="Screenshot 2025-07-21 at 12 06 54" src="https://github.com/user-attachments/assets/32135198-735d-4550-8540-536e318e3766" /> | <img width="620" height="621" alt="Screenshot 2025-07-21 at 12 07 21" src="https://github.com/user-attachments/assets/fbace5c9-28ec-4441-9695-381beead8b08" /> or <img width="633" height="762" alt="Screenshot 2025-07-21 at 12 07 40" src="https://github.com/user-attachments/assets/d8dc87c8-760e-4765-97c2-19e4d9a8784f" /> |
 




