### PR TITLE
Changed H1 and page title on batch and product screens

### DIFF
--- a/app/views/records/batch.html
+++ b/app/views/records/batch.html
@@ -23,7 +23,7 @@
             "name": "batchNumber",
             "fieldset": {
               "legend": {
-                "text": ("Which batch was it?" if vaccination.vaccinationToday == 'yes' else "Which batch was it?"),
+                "text": "Which batch was it?",
                 "classes": "nhsuk-fieldset__legend--l",
                 "isPageHeading": true
               }

--- a/app/views/records/batch.html
+++ b/app/views/records/batch.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Which batch was used? – Records" %}
+{% set pageName = "Which batch was it? – Records" %}
 
 {% set currentSection = "records" %}
 
@@ -23,7 +23,7 @@
             "name": "batchNumber",
             "fieldset": {
               "legend": {
-                "text": ("Which batch was used?" if vaccination.vaccinationToday == 'yes' else "Which batch was used?"),
+                "text": ("Which batch was it?" if vaccination.vaccinationToday == 'yes' else "Which batch was it?"),
                 "classes": "nhsuk-fieldset__legend--l",
                 "isPageHeading": true
               }

--- a/app/views/records/choose-product.html
+++ b/app/views/records/choose-product.html
@@ -23,7 +23,7 @@
           name: "vaccineProduct",
           fieldset: {
             legend: {
-              text: "Which " + vaccination.vaccine + " vaccine did you give?",
+              text: "Which " + vaccination.vaccine + " vaccine product was it?",
               classes: "nhsuk-fieldset__legend--l",
               isPageHeading: true
             }


### PR DESCRIPTION
Changed 'Which batch was used?' to 'Which batch was it?' (consistent with the retrospective journey)

And added 'product' to the H1 for editing the product. So the H1 is now: Which ((vaccination type)) vaccine product was it?  
