### PR TITLE
Split MMR into 2 vaccines for different doses

### DIFF
--- a/app/data/vaccines.js
+++ b/app/data/vaccines.js
@@ -77,7 +77,18 @@ module.exports = [
     ]
   },
   {
-    name: "MMR",
+    name: "MMR (first dose)",
+    products: [
+      {
+        name: "MMRVaXPro"
+      },
+      {
+        name: "Priorix"
+      }
+    ]
+  },
+  {
+    name: "MMR (second dose)",
     products: [
       {
         name: "MMRVaXPro"

--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -823,7 +823,7 @@ module.exports = router => {
 
     if (data.newBatchNumber === '' || data.newBatchExpiryDate?.day === '' || data.newBatchExpiryDate?.month === '' || data.newBatchExpiryDate?.year === '') {
       nextPage = "/record-vaccinations/add-batch?showErrors=yes"
-    } else if ((data.vaccine === "pertussis") || (data.vaccine === "MMR")) {
+    } else if ((data.vaccine === "pertussis") || (data.vaccine === "MMR (first dose)") || (data.vaccine === "MMR (second dose)")) {
       nextPage = "/record-vaccinations/patient"
     } else {
       nextPage = "/record-vaccinations/eligibility"


### PR DESCRIPTION
This separates the MMR vaccine out into 2 separate vaccines, for the first and second dose.

This isn’t ideal, as it will mean users having to add batches separately for both 'types' (when it's the same physical vaccine), but may be required in the short term for technical reasons. 

There’s also the risk that the user selects the wrong dose, as this screen is shown _before_ seeing the patient’s vaccination history, and the patient may not remember whether they’ve had a first dose already or not. However hopefully this is rare, we can display warnings, and the user can go back and switch to the other dose if needed.

## Screenshots

### Before

<img width="852" height="600" alt="Screenshot 2025-07-24 at 14 13 19" src="https://github.com/user-attachments/assets/262feb37-17a5-457d-aa4b-6c20c8aa9dd7" />

### After

<img width="936" height="643" alt="Screenshot 2025-07-24 at 14 12 54" src="https://github.com/user-attachments/assets/7796c6f3-a0ff-4727-a76a-06179af90810" />
