### PR TITLE
Changes to pneumo and MMR warnings

### DIFF
--- a/app/views/record-vaccinations/mmr/warning-age-old.html
+++ b/app/views/record-vaccinations/mmr/warning-age-old.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "Age warning for London MMR service" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -15,7 +15,7 @@
       <h1 class="nhsuk-heading-l">Jodie Brown is too old for the London MMR service</h1>
 
       <p>
-        Jodie Brown is 20 years and 4 days old.
+        Jodie Brown is 20 years old.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/mmr/warning-age-old.html
+++ b/app/views/record-vaccinations/mmr/warning-age-old.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Age warning for London MMR service" %}
+{% set pageName = "The patient is too old for the London MMR service" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/record-vaccinations/mmr/warning-age-young.html
+++ b/app/views/record-vaccinations/mmr/warning-age-young.html
@@ -15,7 +15,7 @@
       <h1 class="nhsuk-heading-l">Jodie Brown is too young for the London MMR service</h1>
 
       <p>
-        Jodie Brown is 4 years.
+        Jodie Brown is 4 years old.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/mmr/warning-age-young.html
+++ b/app/views/record-vaccinations/mmr/warning-age-young.html
@@ -19,7 +19,7 @@
       </p>
 
       <p>
-        To be eligible for this service, you have to be aged 5 or older. Refer this patient to their GP for a vaccination.
+        To be eligible for this service, you have to be aged 5 years or over. Refer this patient to their GP for a vaccination.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/mmr/warning-age-young.html
+++ b/app/views/record-vaccinations/mmr/warning-age-young.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "The patient is too young for the London MMR service" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -15,7 +15,7 @@
       <h1 class="nhsuk-heading-l">Jodie Brown is too young for the London MMR service</h1>
 
       <p>
-        Jodie Brown is 4 years and 364 days old.
+        Jodie Brown is 4 years.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/mmr/warning-dose.html
+++ b/app/views/record-vaccinations/mmr/warning-dose.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "The patient has already had 2 doses of MMR" %}
+{% set pageName = "The patient has already had 2 MMR vaccines" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -12,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Jodie Brown has already had 2 doses of MMR</h1>
+      <h1 class="nhsuk-heading-l">Jodie Brown has already had 2 MMR vaccines</h1>
 
       <p>
         Jodie Brown had a second MMR vaccine on 10 July 2025.

--- a/app/views/record-vaccinations/mmr/warning-dose.html
+++ b/app/views/record-vaccinations/mmr/warning-dose.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "The patient has already had 2 doses of MMR" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/record-vaccinations/mmr/warning-dose.html
+++ b/app/views/record-vaccinations/mmr/warning-dose.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "The patient has already had 2 MMR vaccines" %}
+{% set pageName = "The patient has already had 2 MMR vaccinations" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -12,10 +12,10 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Jodie Brown has already had 2 MMR vaccines</h1>
+      <h1 class="nhsuk-heading-l">Jodie Brown has already had 2 MMR vaccinations</h1>
 
       <p>
-        Jodie Brown had a second MMR vaccine on 10 July 2025.
+        Jodie Brown had a second MMR vaccination on 10 July 2025.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/mmr/warning.html
+++ b/app/views/record-vaccinations/mmr/warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "MMR vaccine interval warning" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/record-vaccinations/mmr/warning.html
+++ b/app/views/record-vaccinations/mmr/warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "MMR vaccine interval warning" %}
+{% set pageName = "The patient had an MMR vaccination less than 1 month ago" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -12,10 +12,10 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Jodie Brown had an MMR vaccine less than 1 month ago</h1>
+      <h1 class="nhsuk-heading-l">Jodie Brown had an MMR vaccination less than 1 month ago</h1>
 
       <p>
-        Jodie Brown had an MMR vaccine on 10 July 2025.
+        Jodie Brown had an MMR vaccination on 10 July 2025.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/ppv/warning-age-young.html
+++ b/app/views/record-vaccinations/ppv/warning-age-young.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "Age warning for pneumococcal vaccine service" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -16,7 +16,7 @@
       </h1>
 
       <p>
-        Jodie Brown is 17 years and 364 days old. 
+        Jodie Brown is 17 years old. 
       </p>
 
       <p>

--- a/app/views/record-vaccinations/ppv/warning-age-young.html
+++ b/app/views/record-vaccinations/ppv/warning-age-young.html
@@ -20,7 +20,7 @@
       </p>
 
       <p>
-        To be eligible for this service, you have to be 18 or older.
+        To be eligible for this service, you have to be aged 18 or older.
       </p>
 
       <p>

--- a/app/views/record-vaccinations/ppv/warning-age-young.html
+++ b/app/views/record-vaccinations/ppv/warning-age-young.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Age warning for pneumococcal vaccine service" %}
+{% set pageName = "The patient is too young for the London pneumococcal service" %}
 
 {% set currentSection = "vaccinate" %}
 

--- a/app/views/record-vaccinations/ppv/warning.html
+++ b/app/views/record-vaccinations/ppv/warning.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "COVID-19 vaccine interval warning" %}
+{% set pageName = "The patient has already had a pneumococcal vaccine" %}
 
 {% set currentSection = "vaccinate" %}
 


### PR DESCRIPTION
Amended page titles for all the MMR and pneumo warnings. 

Amended age, removing days, for the age-related warnings. 

Made some other small content changes to align wording on age more closely with the NHS content guide.
