### PR TITLE
Update to pack size on add-batch.html

### DIFF
--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -59,14 +59,14 @@
             },
             "items": [
               {
-                "value": "Single vial",
-                "text": "Single vial",
-                checked: (data.packType == "Single vial")
+                "value": "Single item",
+                "text": "Single item",
+                checked: (data.packType == "Single item")
               },
               {
-                "value": "10 vials",
-                "text": "10 vials",
-                checked: (data.packType == "10 vials")
+                "value": "10 items",
+                "text": "10 items",
+                checked: (data.packType == "10 items")
               }
             ]
           }) }}


### PR DESCRIPTION
Changed answer options from Single vial/10 vials to Single item/10 items.

This is because from Sept 2025 we are also asking for pack size for flu (if it's a CP or PCN and products comes in different pack sizes). And not all products come in vials. 