### PR TITLE
Simplify radios and checkboxes macro options

### DIFF
--- a/app/views/alerts/new.html
+++ b/app/views/alerts/new.html
@@ -65,16 +65,15 @@
                 classes: "nhsuk-fieldset__legend--s"
               }
             },
+            value: data.packType,
             "items": [
               {
                 "value": "Single vial",
-                "text": "Single vial",
-                checked: (data.packType == "Single vial")
+                "text": "Single vial"
               },
               {
                 "value": "10 vials",
-                "text": "10 vials",
-                checked: (data.packType == "10 vials")
+                "text": "10 vials"
               }
             ]
           }) }}

--- a/app/views/lists/record/batch.html
+++ b/app/views/lists/record/batch.html
@@ -37,6 +37,7 @@
                 "isPageHeading": true
               }
             },
+            value: data.vaccineBatch,
             errorMessage: {
               text: error.text
             } if error,
@@ -46,40 +47,35 @@
                 "text": "AB2345",
                 hint: {
                   text: "Expires 14 August 2025"
-                },
-                checked: (data.vaccineBatch == "AB2345")
+                }
               },
               {
                 "value": "DE8342",
                 "text": "DE8342",
                 hint: {
                   text: "Expires 19 August 2025"
-                },
-                checked: (data.vaccineBatch == "DE8342")
+                }
               },
               {
                 "value": "LF842",
                 "text": "LF842",
                 hint: {
                   text: "Expires 28 August 2025"
-                },
-                checked: (data.vaccineBatch == "LF842")
+                }
               },
               {
                 "value": "JD8352",
                 "text": "JD8352",
                 hint: {
                   text: "Expires 3 September 2025"
-                },
-                checked: (data.vaccineBatch == "JD8352")
+                }
               },
               {
                 divider: "or"
               },
               {
                 "value": "add-new",
-                "text": "Add a batch",
-                checked: (data.vaccineBatch == "add-new")
+                "text": "Add a batch"
               }
             ]
           }) }}

--- a/app/views/lists/record/consent.html
+++ b/app/views/lists/record/consent.html
@@ -134,11 +134,11 @@
           errorMessage: {
             text: consentError.text
           } if consentError,
+          value: data.consent,
           items: [
             {
               value: 'patient',
-              text: (data.patientName or "Michael James"),
-              checked: (data.consent === 'patient')
+              text: (data.patientName or "Michael James")
             },
             {
               divider: "or"
@@ -146,7 +146,6 @@
             {
               value: "Clinician acting in the patient’s best interests",
               text: "Clinician acting in the patient’s best interests",
-              checked: (data.consent === "Clinician acting in the patient’s best interests"),
               conditional: {
                 html: consentClinicianHtml
               }
@@ -154,7 +153,6 @@
             {
                 value: "Person with lasting power of attorney for health and welfare",
                 text: "Person with lasting power of attorney for health and welfare",
-                checked: (data.consent === "Person with lasting power of attorney for health and welfare"),
                 conditional: {
                   html: consentAttorneyHtml
                 }
@@ -162,7 +160,6 @@
               {
                 value: "Parent or guardian",
                 text: "Parent or guardian",
-                checked: (data.consent === "Parent or guardian"),
                 conditional: {
                   html: consentParentHtml
                 }
@@ -170,7 +167,6 @@
               {
                 value: "Independent mental capacity advocate",
                 text: "Independent mental capacity advocate",
-                checked: (data.consent === "Independent mental capacity advocate"),
                 conditional: {
                   html: consentAdvocateHtml
                 }
@@ -178,7 +174,6 @@
               {
                 value: "Court appointed deputy",
                 text: "Court appointed deputy",
-                checked: (data.consent === "Court appointed deputy"),
                 conditional: {
                   html: consentDeputyHtml
                 }

--- a/app/views/lists/record/eligibility.html
+++ b/app/views/lists/record/eligibility.html
@@ -66,8 +66,7 @@
       {% for option in eligibilityOptions %}
         {% set items = (items.push({
           text: option,
-          value: option,
-          checked: (data.eligibility | arrayOrStringIncludes(option))
+          value: option
           }), items) %}
       {% endfor %}
 
@@ -82,6 +81,7 @@
               isPageHeading: true
             }
           },
+          value: data.eligibility,
           items: items
         }) }}
       {% else %}
@@ -91,6 +91,7 @@
             errorMessage: {
               text: (errors | first).text
             } if (errors | length) > 0,
+            values: data.eligibility,
             fieldset: {
               legend: {
                 text: "Why are you giving them the vaccine?",

--- a/app/views/lists/record/injection-site.html
+++ b/app/views/lists/record/injection-site.html
@@ -36,29 +36,26 @@
               classes: "nhsuk-fieldset__legend--s"
             }
           },
+          value: data.otherInjectionSite,
           errorMessage: {
             text: otherInjectionSiteError.text
           } if otherInjectionSiteError,
           items: [
             {
               value: "Left buttock",
-              text: "Left buttock",
-              checked: (data.otherInjectionSite == "Left buttock")
+              text: "Left buttock"
             },
             {
               value: "Right buttock",
-              text: "Right buttock",
-              checked: (data.otherInjectionSite == "Right buttock")
+              text: "Right buttock"
             },
             {
               value: "Left thigh",
-              text: "Left thigh",
-              checked: (data.otherInjectionSite == "Left thigh")
+              text: "Left thigh"
             },
             {
               value: "Right thigh",
-              text: "Right thigh",
-              checked: (data.otherInjectionSite == "Right thigh")
+              text: "Right thigh"
             }
           ]
         }) }}
@@ -78,16 +75,15 @@
           errorMessage: {
             text: injectionSiteError.text
           } if injectionSiteError,
+          value: data.injectionSite,
           items: [
             {
               value: "Left arm",
-              text: "Left arm",
-              checked: (data.injectionSite == 'Left arm')
+              text: "Left arm"
             },
             {
               value: "Right arm",
-              text: "Right arm",
-              checked: (data.injectionSite == 'Right arm')
+              text: "Right arm"
             },
             {
               divider: "or"
@@ -95,7 +91,6 @@
             {
               value: "other",
               text: "Somewhere else",
-              checked: (data.injectionSite == 'other'),
               conditional: {
                 html: somewhereElseHtml
               }

--- a/app/views/lists/record/location.html
+++ b/app/views/lists/record/location.html
@@ -70,47 +70,41 @@
               isPageHeading: true
             }
           },
+          value: data.locationType,
           hint: {
             text: "This is needed for payment and reporting."
           },
           items: [
             {
               text: "Hospital hub for staff and patients",
-              value: "Hospital hub for staff and patients",
-              checked: (data.locationType === "Hospital hub for staff and patients")
+              value: "Hospital hub for staff and patients"
             },
             {
               text: "Vaccination centre open to the public",
-              value: "Vaccination centre open to the public",
-              checked: (data.locationType === "Vaccination centre open to the public")
+              value: "Vaccination centre open to the public"
             },
             {
               text: "Community pharmacy",
-              value: "Community pharmacy",
-              checked: (data.locationType === "Community pharmacy")
+              value: "Community pharmacy"
             },
             {
               value: "Care home",
               text: "Care home",
-              checked: (data.locationType === "Care home"),
               conditional: {
                 html: careHtml
               }
             },
             {
               text: "Housebound patient’s home",
-              value: "Housebound patient’s home",
-              checked: (data.locationType === "Housebound patient’s home")
+              value: "Housebound patient’s home"
             },
             {
               text: "Outreach event",
-              value: "Outreach event",
-              checked: (data.locationType === "Outreach event")
+              value: "Outreach event"
             },
             {
               text: "GP clinic",
-              value: "GP clinic",
-              checked: (data.locationType === "GP clinic")
+              value: "GP clinic"
             }
           ]
 

--- a/app/views/lists/record/vaccinator.html
+++ b/app/views/lists/record/vaccinator.html
@@ -68,19 +68,18 @@
               isPageHeading: "true"
             }
           },
+          value: data.vaccinator,
           errorMessage: {
             text: vaccinatorError
           } if vaccinatorError,
           items: [
             {
               value: "Jane Smith",
-              text: "Me (Jane Smith)",
-              checked: (data.vaccinator === "Jane Smith")
+              text: "Me (Jane Smith)"
             },
             {
               value: "Anna Brown",
-              text: "Anna Brown (anna.brown@nhs.net)",
-              checked: (data.vaccinator === "Anna Brown")
+              text: "Anna Brown (anna.brown@nhs.net)"
             },
             {
               divider: "or"
@@ -88,7 +87,6 @@
             {
               value: "Someone else",
               text: "Someone else",
-              checked: (data.vaccinator === "Someone else"),
               conditional: {
                 html: otherVaccinatorHtml
               }

--- a/app/views/lists/record/vaccine.html
+++ b/app/views/lists/record/vaccine.html
@@ -55,26 +55,23 @@
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and data.vaccine == "COVID-19",
+          value: data.vaccineProduct,
           "items": [
             {
               "value": "Comirnaty 30 JN.1",
-              "text": "Comirnaty 30 JN.1",
-              checked: (data.vaccineProduct == "Comirnaty 30 JN.1")
+              "text": "Comirnaty 30 JN.1
             },
             {
               "value": "Comirnaty 10 JN.1",
-              "text": "Comirnaty 10 JN.1",
-              checked: (data.vaccineProduct == "Comirnaty 10 JN.1")
+              "text": "Comirnaty 10 JN.1"
             },
             {
               "value": "Comirnaty 3 JN.1",
-              "text": "Comirnaty 3 JN.1",
-              checked: (data.vaccineProduct == "Comirnaty 3 JN.1")
+              "text": "Comirnaty 3 JN.1"
             },
             {
               "value": "Spikevax JN.1",
-              "text": "Spikevax JN.1",
-              checked: (data.vaccineProduct == "Spikevax JN.1")
+              "text": "Spikevax JN.1"
             }
           ]
         }) }}
@@ -89,39 +86,34 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and data.vaccine == "Flu",
           "items": [
             {
               "value": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)",
-              "text": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)",
-              checked: (data.vaccineProduct == "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)")
+              "text": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)"
             },
             {
               "value": "Cell-based Quadrivalent Influenza Vaccine (QIVc)",
-              "text": "Cell-based Quadrivalent Influenza Vaccine (QIVc)",
-              checked: (data.vaccineProduct == "Cell-based Quadrivalent Influenza Vaccine (QIVc)")
+              "text": "Cell-based Quadrivalent Influenza Vaccine (QIVc)"
             },
             {
               "value": "Fluenz (LAIV)",
-              "text": "Fluenz (LAIV)",
-              checked: (data.vaccineProduct == "Fluenz (LAIV)")
+              "text": "Fluenz (LAIV)"
             },
             {
               "value": "Influenza Tetra MYL (QIVe)",
-              "text": "Influenza Tetra MYL (QIVe)",
-              checked: (data.vaccineProduct == "Influenza Tetra MYL (QIVe)")
+              "text": "Influenza Tetra MYL (QIVe)"
             },
             {
               "value": "Quadrivalent Influenza Vaccine (QIVe)",
-              "text": "Quadrivalent Influenza Vaccine (QIVe)",
-              checked: (data.vaccineProduct == "Quadrivalent Influenza Vaccine (QIVe)")
+              "text": "Quadrivalent Influenza Vaccine (QIVe)"
             },
             {
               "value": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)",
-              "text": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)",
-              checked: (data.vaccineProduct == "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)")
+              "text": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)"
             }
           ]
         }) }}
@@ -137,24 +129,22 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and data.vaccine == "Pertussis",
           "items": [
             {
               "value": "Adacel vaccine suspension",
-              "text": "Adacel vaccine suspension",
-              checked: (data.vaccineProduct == "Adacel vaccine suspension")
+              "text": "Adacel vaccine suspension"
             },
             {
               "value": "Boostrix-IPV suspension",
-              "text": "Boostrix-IPV suspension",
-              checked: (data.vaccineProduct == "Boostrix-IPV suspension")
+              "text": "Boostrix-IPV suspension"
             },
             {
               "value": "Repevax vaccine suspension",
-              "text": "Repevax vaccine suspension",
-              checked: (data.vaccineProduct == "Repevax vaccine suspension")
+              "text": "Repevax vaccine suspension"
             }
           ]
         }) }}
@@ -169,14 +159,14 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and data.vaccine == "RSV",
           "items": [
             {
               "value": "Abrysvo",
-              "text": "Abrysvo",
-              checked: (data.vaccineProduct == "Abrysvo")
+              "text": "Abrysvo"
             }
           ]
         }) }}
@@ -199,6 +189,7 @@
             "isPageHeading": true
           }
         },
+        value: data.vaccine,
         errorMessage: {
           text: vaccineError
         } if vaccineError,
@@ -206,7 +197,6 @@
           {
             "value": "COVID-19",
             "text": "COVID-19",
-            checked: (data.vaccine == "COVID-19"),
             conditional: {
               html: covid19Product
             }
@@ -214,7 +204,6 @@
           {
             "value": "Flu",
             "text": "Flu",
-            checked: (data.vaccine == "Flu"),
             conditional: {
               html: fluProduct
             }
@@ -222,7 +211,6 @@
           {
             "value": "Pertussis",
             "text": "Pertussis",
-            checked: (data.vaccine == "Pertussis"),
             conditional: {
               html: pertussisProduct
             }
@@ -230,7 +218,6 @@
           {
             "value": "RSV",
             "text": "RSV",
-            checked: (data.vaccine == "RSV"),
             conditional: {
               html: rsvProduct
             }

--- a/app/views/record-vaccinations/consent.html
+++ b/app/views/record-vaccinations/consent.html
@@ -134,11 +134,11 @@
           errorMessage: {
             text: consentError.text
           } if consentError,
+          value: data.content,
           items: [
             {
               value: 'patient',
-              text: (data.patientName or "Jodie Brown"),
-              checked: (data.consent === 'patient')
+              text: (data.patientName or "Jodie Brown")
             },
             {
               divider: "or"
@@ -146,7 +146,6 @@
             {
               value: "Clinician acting in the patient’s best interests",
               text: "Clinician acting in the patient’s best interests",
-              checked: (data.consent === "Clinician acting in the patient’s best interests"),
               conditional: {
                 html: consentClinicianHtml
               }
@@ -154,7 +153,6 @@
             {
                 value: "Person with lasting power of attorney for health and welfare",
                 text: "Person with lasting power of attorney for health and welfare",
-                checked: (data.consent === "Person with lasting power of attorney for health and welfare"),
                 conditional: {
                   html: consentAttorneyHtml
                 }
@@ -162,7 +160,6 @@
               {
                 value: "Parent or guardian",
                 text: "Parent or guardian",
-                checked: (data.consent === "Parent or guardian"),
                 conditional: {
                   html: consentParentHtml
                 }
@@ -170,7 +167,6 @@
               {
                 value: "Independent mental capacity advocate",
                 text: "Independent mental capacity advocate",
-                checked: (data.consent === "Independent mental capacity advocate"),
                 conditional: {
                   html: consentAdvocateHtml
                 }
@@ -178,7 +174,6 @@
               {
                 value: "Court appointed deputy",
                 text: "Court appointed deputy",
-                checked: (data.consent === "Court appointed deputy"),
                 conditional: {
                   html: consentDeputyHtml
                 }

--- a/app/views/record-vaccinations/consent.html
+++ b/app/views/record-vaccinations/consent.html
@@ -134,7 +134,7 @@
           errorMessage: {
             text: consentError.text
           } if consentError,
-          value: data.content,
+          value: data.consent,
           items: [
             {
               value: 'patient',

--- a/app/views/record-vaccinations/create-a-record.html
+++ b/app/views/record-vaccinations/create-a-record.html
@@ -117,26 +117,23 @@
                 errorMessage: {
                   text: genderError
                 } if genderError,
+                value: data.gender,
                 items: [
                 {
                     value: "Male",
-                    text: "Male",
-                    checked: (data.gender === "Male")
+                    text: "Male"
                 },
                 {
                     value: "Female",
-                    text: "Female",
-                    checked: (data.gender === "Female")
+                    text: "Female"
                 },
                 {
                     value: "Other",
-                    text: "Other",
-                    checked: (data.gender === "Other")
+                    text: "Other"
                 },
                 {
                     value: "Unknown",
-                    text: "Unknown",
-                    checked: (data.gender === "Unknown")
+                    text: "Unknown"
                 }
                 ]
             }) }}

--- a/app/views/record-vaccinations/index.html
+++ b/app/views/record-vaccinations/index.html
@@ -62,19 +62,18 @@
               isPageHeading: "true"
             }
           },
+          value: data.vaccinationToday,
           errorMessage: {
             text: vaccinationTodayError
           } if vaccinationTodayError,
           items: [
             {
               value: "yes",
-              text: "Yes",
-              checked: (data.vaccinationToday == 'yes')
+              text: "Yes"
             },
             {
               value: "no",
               text: "No, it was on a previous date",
-              checked: (data.vaccinationToday == 'no'),
               conditional: {
                 html: previousDateHtml
               }

--- a/app/views/record-vaccinations/injection-site.html
+++ b/app/views/record-vaccinations/injection-site.html
@@ -35,26 +35,23 @@
           errorMessage: {
             text: otherInjectionSiteError.text
           } if otherInjectionSiteError,
+          value: data.otherInjectionSite,
           items: [
             {
               value: "Left buttock",
-              text: "Left buttock",
-              checked: (data.otherInjectionSite == "Left buttock")
+              text: "Left buttock"
             },
             {
               value: "Right buttock",
-              text: "Right buttock",
-              checked: (data.otherInjectionSite == "Right buttock")
+              text: "Right buttock"
             },
             {
               value: "Left thigh",
-              text: "Left thigh",
-              checked: (data.otherInjectionSite == "Left thigh")
+              text: "Left thigh"
             },
             {
               value: "Right thigh",
-              text: "Right thigh",
-              checked: (data.otherInjectionSite == "Right thigh")
+              text: "Right thigh"
             }
           ]
         }) }}
@@ -71,24 +68,22 @@
               isPageHeading: true
             }
           },
+          value: data.injectionSite,
           errorMessage: {
             text: injectionSiteError.text
           } if injectionSiteError,
           items: [
             {
               value: "Left arm",
-              text: "Left arm",
-              checked: (data.injectionSite == 'Left arm')
+              text: "Left arm"
             },
             {
               value: "Right arm",
-              text: "Right arm",
-              checked: (data.injectionSite == 'Right arm')
+              text: "Right arm"
             },
             {
               value: "Nose",
-              text: "Nose",
-              checked: (data.injectionSite == 'Nose')
+              text: "Nose"
             },
             {
               divider: "or"
@@ -96,7 +91,6 @@
             {
               value: "other",
               text: "Somewhere else",
-              checked: (data.injectionSite == 'other'),
               conditional: {
                 html: somewhereElseHtml
               }

--- a/app/views/record-vaccinations/patient.html
+++ b/app/views/record-vaccinations/patient.html
@@ -56,20 +56,19 @@
               isPageHeading: "true"
             }
           },
+          value: data.nhsNumberKnown,
           errorMessage: nhsNumberKnownError if nhsNumberKnownError,
           items: [
             {
               value: "yes",
               text: "Yes",
-              checked: (data.nhsNumberKnown == 'yes'),
               conditional: {
                 html: nhsNumberHtml
               }
             },
             {
               value: "no",
-              text: "No",
-              checked: (data.nhsNumberKnown == 'no')
+              text: "No"
             }
           ]
         }) }}

--- a/app/views/records/batch.html
+++ b/app/views/records/batch.html
@@ -28,54 +28,49 @@
                 "isPageHeading": true
               }
             },
+            value: data.batchNumber,
             "items": [
               {
                 "value": "AB2345",
                 "text": "AB2345",
                 hint: {
                   text: "Expires 14 February 2025"
-                },
-                checked: (vaccination.batchNumber == "AB2345")
+                }
               },
               {
                 "value": "DE8342",
                 "text": "DE8342",
                 hint: {
                   text: "Expires 19 February 2025"
-                },
-                checked: (vaccination.batchNumber == "DE8342")
+                }
               },
               {
                 "value": "LF842",
                 "text": "LF842",
                 hint: {
                   text: "Expires 28 February 2025"
-                },
-                checked: (vaccination.batchNumber == "LF842")
+                }
               },
               {
                 "value": "XT1234",
                 "text": "XT1234",
                 hint: {
                   text: "Expired 3 March 2024"
-                },
-                checked: (vaccination.batchNumber == "XT1234")
+                }
               },
               {
                 "value": "PU1234",
                 "text": "PU1234",
                 hint: {
                   text: "Expired 28 February 2024"
-                },
-                checked: (vaccination.batchNumber == "PU1234")
+                }
               },
               {
                 "value": "HN6543",
                 "text": "HN6543",
                 hint: {
                   text: "Expired 22 January 2024"
-                },
-                checked: (vaccination.batchNumber == "HN6543")
+                }
               }
             ]
           }) }}

--- a/app/views/records/by-batch.html
+++ b/app/views/records/by-batch.html
@@ -28,54 +28,49 @@
                 "isPageHeading": true
               }
             },
+            value: data.batchNumber,
             "items": [
               {
                 "value": "AB2345",
                 "text": "AB2345",
                 hint: {
                   text: "Expires 14 February 2025"
-                },
-                checked: (vaccination.batchNumber == "AB2345")
+                }
               },
               {
                 "value": "DE8342",
                 "text": "DE8342",
                 hint: {
                   text: "Expires 19 February 2025"
-                },
-                checked: (vaccination.batchNumber == "DE8342")
+                }
               },
               {
                 "value": "LF842",
                 "text": "LF842",
                 hint: {
                   text: "Expires 28 February 2025"
-                },
-                checked: (vaccination.batchNumber == "LF842")
+                }
               },
               {
                 "value": "XT1234",
                 "text": "XT1234",
                 hint: {
                   text: "Expired 3 March 2024"
-                },
-                checked: (vaccination.batchNumber == "XT1234")
+                }
               },
               {
                 "value": "PU1234",
                 "text": "PU1234",
                 hint: {
                   text: "Expired 28 February 2024"
-                },
-                checked: (vaccination.batchNumber == "PU1234")
+                }
               },
               {
                 "value": "HN6543",
                 "text": "HN6543",
                 hint: {
                   text: "Expired 22 January 2024"
-                },
-                checked: (vaccination.batchNumber == "HN6543")
+                }
               }
             ]
           }) }}

--- a/app/views/records/choose-dates.html
+++ b/app/views/records/choose-dates.html
@@ -73,12 +73,12 @@
           },
           errorMessage: {
             text: vaccinationTodayError
-          } if vaccinationTodayError,
+          } if va'ccinationTodayError,
+          value: "no",
           items: [
             {
               value: "no",
-              text: (vaccination.date | isoDateFromDateInput | govukDate),
-              checked: true
+              text: (vaccination.date | isoDateFromDateInput | govukDate)
             },
             {
               value: "yes",

--- a/app/views/records/choose-product.html
+++ b/app/views/records/choose-product.html
@@ -28,16 +28,15 @@
               isPageHeading: true
             }
           },
+          value: data.vaccineProduct,
           items: [
             {
               value: "Abrysvo",
-              text: "Abrysvo",
-              checked: (data.vaccineProduct === "Abrysvo")
+              text: "Abrysvo"
             },
             {
               value: "Arexvy",
-              text: "Arexvy (example only)",
-              checked: (data.vaccineProduct === "Arexvy")
+              text: "Arexvy (example only)"
             }
           ]
         }) }}

--- a/app/views/records/choose-vaccines.html
+++ b/app/views/records/choose-vaccines.html
@@ -55,26 +55,23 @@
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and vaccination.vaccine == "COVID-19",
+          value: data.vaccineProduct,
           "items": [
             {
               "value": "Comirnaty 30 JN.1",
-              "text": "Comirnaty 30 JN.1",
-              checked: (vaccination.vaccineProduct == "Comirnaty 30 JN.1")
+              "text": "Comirnaty 30 JN.1"
             },
             {
               "value": "Comirnaty 10 JN.1",
-              "text": "Comirnaty 10 JN.1",
-              checked: (vaccination.vaccineProduct == "Comirnaty 10 JN.1")
+              "text": "Comirnaty 10 JN.1"
             },
             {
               "value": "Comirnaty 3 JN.1",
-              "text": "Comirnaty 3 JN.1",
-              checked: (vaccination.vaccineProduct == "Comirnaty 3 JN.1")
+              "text": "Comirnaty 3 JN.1"
             },
             {
               "value": "Spikevax JN.1",
-              "text": "Spikevax JN.1",
-              checked: (vaccination.vaccineProduct == "Spikevax JN.1")
+              "text": "Spikevax JN.1"
             }
           ]
         }) }}
@@ -89,39 +86,34 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and vaccination.vaccine == "Flu",
           "items": [
             {
               "value": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)",
-              "text": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)",
-              checked: (vaccination.vaccineProduct == "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)")
+              "text": "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)"
             },
             {
               "value": "Cell-based Quadrivalent Influenza Vaccine (QIVc)",
-              "text": "Cell-based Quadrivalent Influenza Vaccine (QIVc)",
-              checked: (vaccination.vaccineProduct == "Cell-based Quadrivalent Influenza Vaccine (QIVc)")
+              "text": "Cell-based Quadrivalent Influenza Vaccine (QIVc)"
             },
             {
               "value": "Fluenz (LAIV)",
-              "text": "Fluenz (LAIV)",
-              checked: (vaccination.vaccineProduct == "Fluenz (LAIV)")
+              "text": "Fluenz (LAIV)"
             },
             {
               "value": "Influenza Tetra MYL (QIVe)",
-              "text": "Influenza Tetra MYL (QIVe)",
-              checked: (vaccination.vaccineProduct == "Influenza Tetra MYL (QIVe)")
+              "text": "Influenza Tetra MYL (QIVe)"
             },
             {
               "value": "Quadrivalent Influenza Vaccine (QIVe)",
-              "text": "Quadrivalent Influenza Vaccine (QIVe)",
-              checked: (vaccination.vaccineProduct == "Quadrivalent Influenza Vaccine (QIVe)")
+              "text": "Quadrivalent Influenza Vaccine (QIVe)"
             },
             {
               "value": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)",
-              "text": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)",
-              checked: (vaccination.vaccineProduct == "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)")
+              "text": "Quadrivalent Influenza Vaccine - High Dose (QIV-HD)"
             }
           ]
         }) }}
@@ -137,24 +129,22 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and vaccination.vaccine == "Pertussis",
           "items": [
             {
               "value": "Adacel vaccine suspension",
-              "text": "Adacel vaccine suspension",
-              checked: (vaccination.vaccineProduct == "Adacel vaccine suspension")
+              "text": "Adacel vaccine suspension"
             },
             {
               "value": "Boostrix-IPV suspension",
-              "text": "Boostrix-IPV suspension",
-              checked: (vaccination.vaccineProduct == "Boostrix-IPV suspension")
+              "text": "Boostrix-IPV suspension"
             },
             {
               "value": "Repevax vaccine suspension",
-              "text": "Repevax vaccine suspension",
-              checked: (vaccination.vaccineProduct == "Repevax vaccine suspension")
+              "text": "Repevax vaccine suspension"
             }
           ]
         }) }}
@@ -169,14 +159,14 @@
               "text": "Vaccine product"
             }
           },
+          value: data.vaccineProduct,
           errorMessage: {
             text: vaccineProductError
           } if vaccineProductError and vaccination.vaccine == "RSV",
           "items": [
             {
               "value": "Abrysvo",
-              "text": "Abrysvo",
-              checked: (vaccination.vaccineProduct == "Abrysvo")
+              "text": "Abrysvo"
             }
           ]
         }) }}
@@ -199,6 +189,7 @@
             "isPageHeading": true
           }
         },
+        value: data.vaccine,
         errorMessage: {
           text: vaccineError
         } if vaccineError,
@@ -206,7 +197,6 @@
           {
             "value": "COVID-19",
             "text": "COVID-19",
-            checked: (vaccination.vaccine == "COVID-19"),
             conditional: {
               html: covid19Product
             }
@@ -214,7 +204,6 @@
           {
             "value": "Flu",
             "text": "Flu",
-            checked: (vaccination.vaccine == "Flu"),
             conditional: {
               html: fluProduct
             }
@@ -222,7 +211,6 @@
           {
             "value": "Pertussis",
             "text": "Pertussis",
-            checked: (vaccination.vaccine == "Pertussis"),
             conditional: {
               html: pertussisProduct
             }
@@ -230,7 +218,6 @@
           {
             "value": "RSV",
             "text": "RSV",
-            checked: (vaccination.vaccine == "RSV"),
             conditional: {
               html: rsvProduct
             }

--- a/app/views/records/consent.html
+++ b/app/views/records/consent.html
@@ -41,11 +41,11 @@
               isPageHeading: "true"
             }
           },
+          value: data.consent,
           items: [
             {
               value: "Patient",
-              text: vaccination.patient.name,
-              checked: (vaccination.consent === "Patient")
+              text: vaccination.patient.name
             },
             {
               divider: "or"
@@ -53,7 +53,6 @@
             {
               value: "Clinician following the Mental Capacity Act",
               text: "Clinician following the Mental Capacity Act",
-              checked: (vaccination.consent === "Clinician following the Mental Capacity Act"),
               conditional: {
                 html: otherConsentHtml
               }
@@ -61,7 +60,6 @@
             {
                 value: "Person with power of attorney for personal welfare",
                 text: "Person with power of attorney for personal welfare",
-                checked: (vaccination.consent === "Person with power of attorney for personal welfare"),
                 conditional: {
                   html: otherConsentHtml
                 }
@@ -69,7 +67,6 @@
               {
                 value: "Parent or guardian",
                 text: "Parent or guardian",
-                checked: (vaccination.consent === "Parent or guardian"),
                 conditional: {
                   html: otherConsentHtml
                 }
@@ -77,7 +74,6 @@
               {
                 value: "Mental capacity advocate",
                 text: "Mental capacity advocate",
-                checked: (vaccination.consent === "Mental capacity advocate"),
                 conditional: {
                   html: otherConsentHtml
                 }
@@ -85,7 +81,6 @@
               {
                 value: "Court appointed deputy",
                 text: "Court appointed deputy",
-                checked: (vaccination.consent === "Court appointed deputy"),
                 conditional: {
                   html: otherConsentHtml
                 }

--- a/app/views/records/deactivated.html
+++ b/app/views/records/deactivated.html
@@ -41,19 +41,18 @@
               isPageHeading: false
             }
           },
+          value: data.nhsNumberKnown,
           items: [
             {
               value: "yes",
               text: "NHS number",
-              checked: (data.nhsNumberKnown == 'yes'),
               conditional: {
                 html: nhsNumberHtml
               }
             },
             {
               value: "no",
-              text: "Patient details",
-              checked: (data.nhsNumberKnown == 'no')
+              text: "Patient details"
             }
           ]
         }) }}

--- a/app/views/records/delivery-team.html
+++ b/app/views/records/delivery-team.html
@@ -28,21 +28,19 @@
               isPageHeading: true
             }
           },
+          value: data.deliveryTeam,
           items: [
             {
               value: "Anne Ward Maternity Unit",
-              text: "Anne Ward Maternity Unit",
-              checked: (data.deliveryTeam === "Anne Ward Maternity Unit")
+              text: "Anne Ward Maternity Unit"
             },
             {
               value: "St Mary’s Hospital",
-              text: "St Mary’s Hospital",
-              checked: (data.deliveryTeam === "St Mary’s Hospital")
+              text: "St Mary’s Hospital"
             },
             {
               value: "Josephine Clinic",
-              text: "Josephine Clinic",
-              checked: (data.deliveryTeam === "Josephine Clinic")
+              text: "Josephine Clinic"
             }
           ]
         }) }}

--- a/app/views/records/index.html
+++ b/app/views/records/index.html
@@ -39,19 +39,18 @@
               isPageHeading: false
             }
           },
+          value: data.nhsNumberKnown,
           items: [
             {
               value: "yes",
               text: "NHS number",
-              checked: (data.nhsNumberKnown == 'yes'),
               conditional: {
                 html: nhsNumberHtml
               }
             },
             {
               value: "no",
-              text: "Patient details",
-              checked: (data.nhsNumberKnown == 'no')
+              text: "Patient details"
             }
           ]
         }) }}

--- a/app/views/records/injection-site.html
+++ b/app/views/records/injection-site.html
@@ -31,26 +31,23 @@
               classes: "nhsuk-fieldset__legend--s"
             }
           },
+          value: data.otherInjectionSite,
           items: [
             {
               value: "Left buttock",
-              text: "Left buttock",
-              checked: (vaccination.otherInjectionSite == "Left buttock")
+              text: "Left buttock"
             },
             {
               value: "Right buttock",
-              text: "Right buttock",
-              checked: (vaccination.otherInjectionSite == "Right buttock")
+              text: "Right buttock"
             },
             {
               value: "Left thigh",
-              text: "Left thigh",
-              checked: (vaccination.otherInjectionSite == "Left thigh")
+              text: "Left thigh"
             },
             {
               value: "Right thigh",
-              text: "Right thigh",
-              checked: (vaccination.otherInjectionSite == "Right thigh")
+              text: "Right thigh"
             }
           ]
         }) }}
@@ -67,16 +64,15 @@
               isPageHeading: true
             }
           },
+          value: data.injectionSite,
           items: [
             {
               value: "Left arm",
-              text: "Left arm",
-              checked: (vaccination.injectionSite == 'Left arm')
+              text: "Left arm"
             },
             {
               value: "Right arm",
-              text: "Right arm",
-              checked: (vaccination.injectionSite == 'Right arm')
+              text: "Right arm"
             },
             {
               divider: "or"
@@ -84,7 +80,6 @@
             {
               value: "other",
               text: "Somewhere else",
-              checked: (vaccination.injectionSite == 'other'),
               conditional: {
                 html: somewhereElseHtml
               }

--- a/app/views/records/location.html
+++ b/app/views/records/location.html
@@ -75,44 +75,38 @@
           hint: {
             text: "This is needed for payment and reporting."
           },
+          value: data.locationType,
           items: [
             {
               text: "Hospital hub for staff and patients",
-              value: "Hospital hub for staff and patients",
-              checked: (data.locationType === "Hospital hub for staff and patients")
+              value: "Hospital hub for staff and patients"
             },
             {
               text: "Vaccination centre open to the public",
-              value: "Vaccination centre open to the public",
-              checked: (data.locationType === "Vaccination centre open to the public")
+              value: "Vaccination centre open to the public"
             },
             {
               text: "Community pharmacy",
-              value: "Community pharmacy",
-              checked: (data.locationType === "Community pharmacy")
+              value: "Community pharmacy"
             },
             {
               value: "Care home",
               text: "Care home",
-              checked: (data.locationType === "Care home"),
               conditional: {
                 html: careHtml
               }
             },
             {
               text: "Housebound patient’s home",
-              value: "Housebound patient’s home",
-              checked: (data.locationType === "Housebound patient’s home")
+              value: "Housebound patient’s home"
             },
             {
               text: "Outreach event",
-              value: "Outreach event",
-              checked: (data.locationType === "Outreach event")
+              value: "Outreach event"
             },
             {
               text: "GP clinic",
-              value: "GP clinic",
-              checked: (data.locationType === "GP clinic")
+              value: "GP clinic"
             }
           ]
 

--- a/app/views/records/vaccinator.html
+++ b/app/views/records/vaccinator.html
@@ -71,19 +71,18 @@
               isPageHeading: "true"
             }
           },
+          value: data.vaccinator,
           errorMessage: {
             text: vaccinatorError
           } if vaccinatorError,
           items: [
             {
               value: "Jane Smith",
-              text: "Me (Jane Smith)",
-              checked: (vaccination.vaccinator === "Jane Smith")
+              text: "Me (Jane Smith)"
             },
             {
               value: "Anna Brown",
-              text: "Anna Brown (anna.brown@nhs.net)",
-              checked: (vaccination.vaccinator === "Anna Brown")
+              text: "Anna Brown (anna.brown@nhs.net)"
             },
             {
               divider: "or"
@@ -91,7 +90,6 @@
             {
               value: "Someone else",
               text: "Someone else",
-              checked: (vaccination.vaccinator === "Someone else"),
               conditional: {
                 html: otherVaccinatorHtml
               }

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -39,11 +39,11 @@
               classes: "nhsuk-fieldset__legend--xl"
             }
           },
+          values: data.data,
           items: [
             {
               value: "Patients",
               text: "Patients",
-              checked: (data.data | arrayOrStringIncludes("Patients")),
               hint: {
                 text: "NHS number, name, date of birth, gender, address"
               }
@@ -51,7 +51,6 @@
             {
               value: "Staff",
               text: "Staff",
-              checked: (data.data | arrayOrStringIncludes("Staff")),
               hint: {
                 text: "Recorder or vaccinator names and email addresses"
               }
@@ -59,21 +58,18 @@
             {
               value: "Site or delivery team",
               text: "Site or delivery team",
-              checked: (data.data | arrayOrStringIncludes("Site or delivery team")),
               hint: {
                 text: "Names and ODS codes"
               }
             },{
               value: "Assessment and consent",
               text: "Assessment and consent",
-              checked: (data.data | arrayOrStringIncludes("Assessment and consent")),
               hint: {
                 text: "Vaccinated and not givens, date, consent and eligibility details, and comments"
               }
             },{
               value: "Vaccination",
               text: "Vaccination",
-              checked: (data.data | arrayOrStringIncludes("Vaccination")),
               hint: {
                 text: "Date, vaccine details and dose given, site of body, legal mechanism and comments"
               }

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -126,34 +126,30 @@
               "isPageHeading": true
             }
           },
+          value: data.date,
           errorMessage: {
             text: dateError
           } if dateError,
           "items": [
             {
               "value": "Today",
-              "text": "Today",
-              checked: (data.date == "Today")
+              "text": "Today"
             },
             {
               "value": "Yesterday",
-              "text": "Yesterday",
-              checked: (data.date == "Yesterday")
+              "text": "Yesterday"
             },
             {
               "value": "Last7days",
-              "text": "Last 7 days",
-              checked: (data.date == "Last7days")
+              "text": "Last 7 days"
             },
             {
               "value": "Last14days",
-              "text": "Last 14 days",
-              checked: (data.date == "Last14days")
+              "text": "Last 14 days"
             },
             {
                 "value": "Last31days",
-                "text": "Last 31 days",
-                checked: (data.date == "Last31days")
+                "text": "Last 31 days"
               },
             {
               divider: "or"
@@ -161,7 +157,6 @@
             {
               "value": "custom_date_range",
               "text": "Select custom date range up to 31 days",
-              checked: (data.date == "custom_date_range"),
               conditional: {
                 html: custom_date_range
               }

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -30,27 +30,23 @@
                     isPageHeading: true
                   }
                 },
-
+                values: data.reportSites,
                 "items": [
                   {
                     "value": "Verington (RH63S)",
-                    "text": "Verington (RH63S)",
-                    checked: (data.reportSites | arrayOrStringIncludes("Verington (RH63S)"))
+                    "text": "Verington (RH63S)"
                   },
                   {
                     "value": "Tower (S204X)",
-                    "text": "Tower (S204X)",
-                    checked: (data.reportSites | arrayOrStringIncludes("Tower (S204X)"))
+                    "text": "Tower (S204X)"
                   },
                   {
                     "value": "The Exchange (RH5S9)",
-                    "text": "The Exchange (RH5S9)",
-                    checked: (data.reportSites | arrayOrStringIncludes("The Exchange (RH5S9)"))
+                    "text": "The Exchange (RH5S9)"
                   },
                   {
                     "value": "Willowbank Day Hospital (RH5C4)",
-                    "text": "Willowbank Day Hospital (RH5C4)",
-                    checked: (data.reportSites | arrayOrStringIncludes("Willowbank Day Hospital (RH5C4)"))
+                    "text": "Willowbank Day Hospital (RH5C4)"
                   }
                   ]
               }) }}

--- a/app/views/user-admin/add-user.html
+++ b/app/views/user-admin/add-user.html
@@ -96,17 +96,16 @@
           hint: {
             text: "Vaccination records include the name of the person who gave the vaccination"
           },
+          value: data.vaccinator,
           "items": [
             {
               "value": "yes",
               "text": "Yes",
-              id: "vaccinator",
-              checked: (data.vaccinator == "yes")
+              id: "vaccinator"
             },
             {
               "value": "no",
-              "text": "No",
-              checked: (data.vaccinator == "no")
+              "text": "No"
             }
           ],
           "errorMessage": {

--- a/app/views/vaccines/add-batch-to-site.html
+++ b/app/views/vaccines/add-batch-to-site.html
@@ -57,16 +57,15 @@
                 classes: "nhsuk-fieldset__legend--s"
               }
             },
+            value: data.packType,
             "items": [
               {
                 "value": "Single vial",
-                "text": "Single vial",
-                checked: (data.packType == "Single vial")
+                "text": "Single vial"
               },
               {
                 "value": "10 vials",
-                "text": "10 vials",
-                checked: (data.packType == "10 vials")
+                "text": "10 vials"
               }
             ]
           }) }}

--- a/app/views/vaccines/add-batch.html
+++ b/app/views/vaccines/add-batch.html
@@ -57,16 +57,15 @@
                 classes: "nhsuk-fieldset__legend--s"
               }
             },
+            value: data.packType,
             "items": [
               {
                 "value": "Single item",
-                "text": "Single item",
-                checked: (data.packType == "Single item")
+                "text": "Single item"
               },
               {
                 "value": "10 items",
-                "text": "10 items",
-                checked: (data.packType == "10 items")
+                "text": "10 items"
               }
             ]
           }) }}

--- a/app/views/vaccines/edit-batch.html
+++ b/app/views/vaccines/edit-batch.html
@@ -55,16 +55,15 @@
                 classes: "nhsuk-fieldset__legend--s"
               }
             },
+            value: data.packType,
             "items": [
               {
                 "value": "Single vial",
-                "text": "Single vial",
-                checked: (batch.packType == "Single vial")
+                "text": "Single vial"
               },
               {
                 "value": "10 vials",
-                "text": "10 vials",
-                checked: (batch.packType == "10 vials")
+                "text": "10 vials"
               }
             ]
           }) }}


### PR DESCRIPTION
This removes the remaining use of the `checked` param on radio and checkbox items, instead setting either `value` or `values` at the top level in the macro, which is simpler and easier to maintain.

This feature was added in NHS frontend 9.2.0: https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.2.0