### PR TITLE
Changes to injection site question

### DIFF
--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -957,13 +957,13 @@ module.exports = router => {
 
       if (!injectionSite) {
         injectionSiteError = {
-          text: "Select where you gave the vaccine",
+          text: "Select where you gave the injection",
           href: "#injection-site-1"
         }
         errors.push(injectionSiteError)
       } else if (injectionSite === "other" && !otherInjectionSite) {
         otherInjectionSiteError = {
-          text: "Select where you gave the vaccine",
+          text: "Select where you gave the injection",
           href: "#other-injection-site-1"
         }
         errors.push(otherInjectionSiteError)

--- a/app/views/record-vaccinations/check.html
+++ b/app/views/record-vaccinations/check.html
@@ -336,7 +336,7 @@
           },
           {
             key: {
-              text: "Vaccination site"
+              text: "Injection site"
             },
             value: {
               html: (data.otherInjectionSite if data.injectionSite == "other" else data.injectionSite)
@@ -346,7 +346,7 @@
                 {
                   href: "/record-vaccinations/injection-site",
                   text: "Change",
-                  visuallyHiddenText: "Vaccination site"
+                  visuallyHiddenText: "Injection site"
                 }
               ]
             }

--- a/app/views/record-vaccinations/injection-site.html
+++ b/app/views/record-vaccinations/injection-site.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Where did you give the vaccine?" %}
+{% set pageName = "Where did you give the injection?" %}
 
 {% set currentSection = "vaccinate" %}
 
@@ -28,7 +28,7 @@
           name: "otherInjectionSite",
           fieldset: {
             legend: {
-              text: "Body part",
+              text: "Injection site",
               classes: "nhsuk-fieldset__legend--s"
             }
           },
@@ -63,7 +63,7 @@
           name: "injectionSite",
           fieldset: {
             legend: {
-              text: ("Where did you give the vaccine?" if data.vaccinationToday == 'yes' else "Where was the vaccine given?"),
+              text: ("Where did you give the injection?" if data.vaccinationToday == 'yes' else "Where was the injection given?"),
               classes: "nhsuk-fieldset__legend--l",
               isPageHeading: true
             }
@@ -80,10 +80,6 @@
             {
               value: "Right arm",
               text: "Right arm"
-            },
-            {
-              value: "Nose",
-              text: "Nose"
             },
             {
               divider: "or"


### PR DESCRIPTION
Reverting this question back to how it was. Changing:
- Where did you give the vaccination?' back to 'Where did you give the injection?'
- 'Body part' heading above 'Somewhere else' options back to 'Injection site'