### PR TITLE
Skip injection question for nasal sprays

### DIFF
--- a/app/data/vaccines.js
+++ b/app/data/vaccines.js
@@ -3,16 +3,20 @@ module.exports = [
     name: "COVID-19",
     products: [
       {
-        name: "Comirnaty 30 JN.1"
+        name: "Comirnaty 30 JN.1",
+        type: "injection"
       },
       {
-        name: "Comirnaty 10 JN.1"
+        name: "Comirnaty 10 JN.1",
+        type: "injection"
       },
       {
-        name: "Comirnaty 3 JN.1"
+        name: "Comirnaty 3 JN.1",
+        type: "injection"
       },
       {
-        name: "Spikevax JN.1"
+        name: "Spikevax JN.1",
+        type: "injection"
       }
     ]
   },
@@ -20,25 +24,32 @@ module.exports = [
     name: "flu",
     products: [
       {
-        name: "Adjuvanted Trivalent Influenza Vaccine (aTIV)"
+        name: "Adjuvanted Trivalent Influenza Vaccine (aTIV)",
+        type: "injection"
       },
       {
-        name: "Cell-based Trivalent Influenza Vaccine (TIVc)"
+        name: "Cell-based Trivalent Influenza Vaccine (TIVc)",
+        type: "injection"
       },
       {
-        name: "Efluelda (TIV-HD)"
+        name: "Efluelda (TIV-HD)",
+        type: "injection"
       },
       {
-        name: "Fluenz (LAIV)"
+        name: "Fluenz (LAIV)",
+        type: "nasal spray"
       },
       {
-        name: "Influvac (TIVe)"
+        name: "Influvac (TIVe)",
+        type: "injection"
       },
       {
-        name: "Supemtek (TIVr)"
+        name: "Supemtek (TIVr)",
+        type: "injection"
       },
       {
-        name: "Vaxigrip (TIVe)"
+        name: "Vaxigrip (TIVe)",
+        type: "injection"
       }
     ]
   },
@@ -46,25 +57,32 @@ module.exports = [
     name: "flu (London service)",
     products: [
       {
-        name: "Adjuvanted Trivalent Influenza Vaccine (aTIV)"
+        name: "Adjuvanted Trivalent Influenza Vaccine (aTIV)",
+        type: "injection"
       },
       {
-        name: "Cell-based Trivalent Influenza Vaccine (TIVc)"
+        name: "Cell-based Trivalent Influenza Vaccine (TIVc)",
+        type: "injection"
       },
       {
-        name: "Efluelda (TIV-HD)"
+        name: "Efluelda (TIV-HD)",
+        type: "injection"
       },
       {
-        name: "Fluenz (LAIV)"
+        name: "Fluenz (LAIV)",
+        type: "nasal spray"
       },
       {
-        name: "Influvac (TIVe)"
+        name: "Influvac (TIVe)",
+        type: "injection"
       },
       {
-        name: "Supemtek (TIVr)"
+        name: "Supemtek (TIVr)",
+        type: "injection"
       },
       {
-        name: "Vaxigrip (TIVe)"
+        name: "Vaxigrip (TIVe)",
+        type: "injection"
       }
     ]
   },
@@ -72,13 +90,16 @@ module.exports = [
     name: "pertussis",
     products: [
       {
-        name: "Adacel vaccine suspension"
+        name: "Adacel vaccine suspension",
+        type: "injection"
       },
       {
-        name: "Boostrix-IPV suspension"
+        name: "Boostrix-IPV suspension",
+        type: "injection"
       },
       {
-        name: "Repevax vaccine suspension"
+        name: "Repevax vaccine suspension",
+        type: "injection"
       }
     ]
   },
@@ -86,10 +107,12 @@ module.exports = [
     name: "MMR",
     products: [
       {
-        name: "MMRVaXPro"
+        name: "MMRVaXPro",
+        type: "injection"
       },
       {
-        name: "Priorix"
+        name: "Priorix",
+        type: "injection"
       }
     ]
   },
@@ -97,7 +120,8 @@ module.exports = [
     name: "pneumococcal",
     products: [
       {
-        name: "Pneumovax"
+        name: "Pneumovax",
+        type: "injection"
       }
     ]
   },
@@ -105,7 +129,8 @@ module.exports = [
     name: "RSV",
     products: [
       {
-        name: "Abrysvo"
+        name: "Abrysvo",
+        type: "injection"
       }
     ]
   }

--- a/app/filters.js
+++ b/app/filters.js
@@ -36,7 +36,11 @@ module.exports = function (env) { /* eslint-disable-line no-unused-vars */
   }
 
   filters.capitaliseFirstLetter = function(string) {
-    return string.charAt(0) .toUpperCase() + string.slice(1)
+    if (string) {
+      return string.charAt(0) .toUpperCase() + string.slice(1)
+    } else {
+      return null
+    }
   }
 
   /* ------------------------------------------------------------------

--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -629,8 +629,6 @@ module.exports = router => {
     const healthcareWorker = data.healthcareWorker
     let nextPage
 
-    console.log(healthcareWorker)
-
     if (healthcareWorker && healthcareWorker != '') {
       nextPage = '/record-vaccinations/location'
     } else {
@@ -930,6 +928,8 @@ module.exports = router => {
     const consentDeputyRelationship = data.consentDeputyRelationship
     const consentAttorneyRelationship = data.consentAttorneyRelationship
 
+    const vaccineProduct = data.vaccines.find((vaccine) => vaccine.name === data.vaccine)?.products.find((vaccineProduct) => vaccineProduct.name === data.vaccineProduct)
+
     if (
       (consent === "patient") ||
       (consent === "Clinician acting in the patient’s best interests" && consentClinicianName != '') ||
@@ -938,7 +938,13 @@ module.exports = router => {
       (consent === "Independent mental capacity advocate" && consentAdvocateName != '') ||
       (consent === "Court appointed deputy" && consentDeputyName != '' && consentDeputyRelationship != "")
     ) {
-      res.redirect('/record-vaccinations/injection-site')
+
+      if (vaccineProduct?.type === "nasal spray") {
+        res.redirect('/record-vaccinations/dose-amount')
+      } else {
+        res.redirect('/record-vaccinations/injection-site')
+      }
+
     } else {
       res.redirect('/record-vaccinations/consent?showErrors=yes')
     }
@@ -978,12 +984,16 @@ module.exports = router => {
     })
   })
 
-router.get('/record-vaccinations/check', (req, res) => {
+  router.get('/record-vaccinations/check', (req, res) => {
     const data = req.session.data
     const vaccinator = data.users.find((user) => user.id === data.vaccinatorId)
 
+    // Get the details of the vaccine product
+    const vaccineProduct = data.vaccines.find((vaccine) => vaccine.name === data.vaccine)?.products.find((vaccineProduct) => vaccineProduct.name === data.vaccineProduct)
+
     res.render('record-vaccinations/check', {
-      vaccinator
+      vaccinator,
+      vaccineProduct
     })
   })
 
@@ -1006,10 +1016,6 @@ router.get('/record-vaccinations/check', (req, res) => {
 
     if (!injectionSite || (injectionSite === "other" && !otherInjectionSite)) {
       redirectPath = "/record-vaccinations/injection-site?showErrors=yes"
-    } else if (data.vaccineProduct == "Fluenz (LAIV)") {
-
-      // Fluenz is a nasal spray which gets an extra question
-      redirectPath = "/record-vaccinations/dose-amount"
     }
 
     res.redirect(redirectPath)

--- a/app/views/record-vaccinations/check.html
+++ b/app/views/record-vaccinations/check.html
@@ -5,7 +5,11 @@
 {% set currentSection = "vaccinate" %}
 
 {% block beforeContent %}
-  {{ backLink({ href: "/record-vaccinations/injection-site" }) }}
+  {% if vaccineProduct.type == "nasal spray" %}
+    {{ backLink({ href: "/record-vaccinations/dose-amount" }) }}
+  {% else %}
+    {{ backLink({ href: "/record-vaccinations/injection-site" }) }}
+  {% endif %}
 {% endblock %}
 
 {% set consentHtml %}
@@ -350,7 +354,7 @@
                 }
               ]
             }
-          },
+          } if (vaccineProduct.type == "injection"),
           {
             key: {
               text: "Dose"
@@ -367,7 +371,7 @@
                 }
               ]
             }
-          } if data.doseAmount
+          } if (vaccineProduct.type == "nasal spray")
         ]
       }) }}
 

--- a/app/views/record-vaccinations/dose-amount.html
+++ b/app/views/record-vaccinations/dose-amount.html
@@ -5,7 +5,7 @@
 {% set currentSection = "vaccinate" %}
 
 {% block beforeContent %}
-  {{ backLink({ href: "/record-vaccinations/injection-site" }) }}
+  {{ backLink({ href: "/record-vaccinations/consent" }) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/record-vaccinations/vaccine.html
+++ b/app/views/record-vaccinations/vaccine.html
@@ -13,6 +13,8 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
+      {{ data.vaccineProduct }}
+
       {% if vaccineError %}
         {% set error = {text: vaccineError, href: "#vaccine-1"} %}
       {% elseif vaccineProductError %}


### PR DESCRIPTION
This updates the logic for the flow of the record vaccination journey so that, if the vaccine product is a nasal spray, the 'injection site' question is skipped and instead the 'Was a full dose given?' question is shown.