### PR TITLE
Remove x-govuk prototype components

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,7 +66,6 @@ const appViews = [
   join(__dirname, 'node_modules/nhsuk-frontend/dist/nhsuk/macros'),
   join(__dirname, 'node_modules/nhsuk-frontend/dist/nhsuk'),
   join(__dirname, 'node_modules/nhsuk-frontend/dist'),
-  join(__dirname, 'node_modules/@x-govuk/govuk-prototype-components/src/x-govuk/components'),
   join(__dirname, 'app/components/'),
 ]
 

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -11,22 +11,6 @@
 @import 'components/feedback-panel';
 @import 'components/checkboxes';
 
-// Import GOVUK-frontend
-//
-// This is so we can use a few components within the GOV.UK Design System
-// which aren’t yet part of the NHS Design System
-@import "govuk-frontend/dist/govuk/all";
-
-// Reset some GOV.UK variables to be NHS-branded
-$govuk-font-family: 'Frutiger W01';
-$govuk-error-colour: $nhsuk-error-colour;
-$govuk-input-border-colour: $nhsuk-form-border-colour;
-$govuk-brand-colour: $nhsuk-link-colour;
-
-// Import X-GOVUK prototype components
-@import "node_modules/@x-govuk/govuk-prototype-components/src/x-govuk";
-
-
 // Local components or modifiers
 @import 'components/header';
 @import 'components/summary-list';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ function compileStyles() {
     })
     .pipe(
       sass({
-        loadPaths: ['node_modules', '.'],
+        loadPaths: ['node_modules'],
         sourceMap: true,
         sourceMapIncludeSources: true
       }).on('error', (error) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/core": "^7.28.3",
         "@babel/preset-env": "^7.28.3",
         "@inquirer/prompts": "^7.5.3",
-        "@x-govuk/govuk-prototype-components": "^4.0.1",
         "@x-govuk/govuk-prototype-filters": "^2.0.0",
         "body-parser": "^2.2.0",
         "browser-sync": "^3.0.4",
@@ -4085,22 +4084,6 @@
         "win32"
       ]
     },
-    "node_modules/@x-govuk/govuk-prototype-components": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-4.0.1.tgz",
-      "integrity": "sha512-2FaiIGGhOPYOzsDVXiqWUFLgrzRjB4CMKbXiZuFDDKYpD/S2bBNK4XoTm6WsfTFd0+WD4t7DQ1DQQsG+P7clUA==",
-      "license": "MIT",
-      "dependencies": {
-        "accessible-autocomplete": "^3.0.0",
-        "eventslibjs": "^1.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24"
-      },
-      "peerDependencies": {
-        "govuk-frontend": "^5.0.0"
-      }
-    },
     "node_modules/@x-govuk/govuk-prototype-filters": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-filters/-/govuk-prototype-filters-2.0.0.tgz",
@@ -4153,19 +4136,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/accessible-autocomplete": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.0.tgz",
-      "integrity": "sha512-Kpm6EX+jjD0AurWfzSP4EVLEKsLUWCazZwidjum+8FCRtSINeaPzVa3ElKVGWvSqVZN9zjeSBF8cirhYEZjW1A==",
-      "peerDependencies": {
-        "preact": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "preact": {
-          "optional": true
-        }
       }
     },
     "node_modules/acorn": {
@@ -7574,11 +7544,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
-    "node_modules/eventslibjs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventslibjs/-/eventslibjs-1.2.0.tgz",
-      "integrity": "sha512-nui7FHXHeeZjWkQ1dZ4R3RchkT+164+y1/puiOY1Zc3CPU9W8XzAzdhqvuVQ4EJt7F/W94O5U26/oVFpBOPY3w=="
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -8838,15 +8803,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/govuk-frontend": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.5.0.tgz",
-      "integrity": "sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.2.0"
       }
     },
     "node_modules/govuk-markdown": {
@@ -20673,15 +20629,6 @@
       "dev": true,
       "optional": true
     },
-    "@x-govuk/govuk-prototype-components": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-4.0.1.tgz",
-      "integrity": "sha512-2FaiIGGhOPYOzsDVXiqWUFLgrzRjB4CMKbXiZuFDDKYpD/S2bBNK4XoTm6WsfTFd0+WD4t7DQ1DQQsG+P7clUA==",
-      "requires": {
-        "accessible-autocomplete": "^3.0.0",
-        "eventslibjs": "^1.2.0"
-      }
-    },
     "@x-govuk/govuk-prototype-filters": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-filters/-/govuk-prototype-filters-2.0.0.tgz",
@@ -20720,12 +20667,6 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
-    },
-    "accessible-autocomplete": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.0.tgz",
-      "integrity": "sha512-Kpm6EX+jjD0AurWfzSP4EVLEKsLUWCazZwidjum+8FCRtSINeaPzVa3ElKVGWvSqVZN9zjeSBF8cirhYEZjW1A==",
-      "requires": {}
     },
     "acorn": {
       "version": "8.15.0",
@@ -23064,11 +23005,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
-    "eventslibjs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventslibjs/-/eventslibjs-1.2.0.tgz",
-      "integrity": "sha512-nui7FHXHeeZjWkQ1dZ4R3RchkT+164+y1/puiOY1Zc3CPU9W8XzAzdhqvuVQ4EJt7F/W94O5U26/oVFpBOPY3w=="
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -23972,12 +23908,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "govuk-frontend": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.5.0.tgz",
-      "integrity": "sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==",
-      "peer": true
     },
     "govuk-markdown": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@babel/core": "^7.28.3",
     "@babel/preset-env": "^7.28.3",
     "@inquirer/prompts": "^7.5.3",
-    "@x-govuk/govuk-prototype-components": "^4.0.1",
     "@x-govuk/govuk-prototype-filters": "^2.0.0",
     "body-parser": "^2.2.0",
     "browser-sync": "^3.0.4",


### PR DESCRIPTION
These are no longer needed as the secondary navigation component has been copied in.

Removing it means we no longer need to import govuk-frontend.