### PR TITLE
Bugfix: use strings for dates when generating records

### DIFF
--- a/app/routes/helpers.js
+++ b/app/routes/helpers.js
@@ -85,9 +85,9 @@ module.exports = router => {
         id: generatedId,
         siteId: "RW3NM",
         date: {
-          day: dayToday,
-          month: monthToday,
-          year: yearToday
+          day: dayToday.toString(),
+          month: monthToday.toString(),
+          year: yearToday.toString()
         },
         vaccine: "RSV",
         vaccineProduct: "Abrysvo",


### PR DESCRIPTION
This is currently needed for the date formatter to work.