### PR TITLE
Design spike: filtering records

### DIFF
--- a/app/assets/sass/components/_card.scss
+++ b/app/assets/sass/components/_card.scss
@@ -1,0 +1,9 @@
+@use "sass:color";
+
+.app-card--filters {
+  background-color: color.scale(nhsuk-colour("grey-4"), $alpha: -50%);
+
+  .nhsuk-card__heading--feature {
+    background-color: nhsuk-colour("grey-1");
+  }
+}

--- a/app/assets/sass/components/_checkboxes.scss
+++ b/app/assets/sass/components/_checkboxes.scss
@@ -3,3 +3,30 @@
 .nhsuk-label {
   box-sizing: border-box;
 }
+
+
+.app-checkboxes--small {
+
+  .nhsuk-checkboxes__item,
+  .nhsuk-radios__item {
+    margin-bottom: 0;
+  }
+
+  .nhsuk-checkboxes__label,
+  .nhsuk-radios__label {
+    padding-left: 0;
+
+    &::before {
+      border-width: 3px;
+      padding: 0;
+      transform: scale(0.6667);
+      transform-origin: center left;
+    }
+
+    &::after {
+      box-sizing: border-box;
+      left: 3px;
+      transform: rotate(-45deg) scale(0.6667);
+    }
+  }
+}

--- a/app/assets/sass/components/_search.scss
+++ b/app/assets/sass/components/_search.scss
@@ -1,0 +1,20 @@
+.app-search {
+  display: flex;
+  gap: nhsuk-spacing(1);
+
+
+  .app-search--input {
+    display: flex;
+    flex: 1;
+    margin: 0;
+  }
+
+  .nhsuk-form-group {
+    width: 100%;
+  }
+
+  .app-search--button {
+    display: flex;
+    flex: 0;
+  }
+}

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -18,6 +18,7 @@
 @import 'components/table';
 @import 'components/button';
 @import 'components/filters';
+@import 'components/search';
 @import 'components/section';
 @import 'components/tag';
 @import 'components/numbered-heading';

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -12,6 +12,7 @@
 @import 'components/checkboxes';
 
 // Local components or modifiers
+@import 'components/card';
 @import 'components/header';
 @import 'components/summary-list';
 @import 'components/table';

--- a/app/lib/utils/random-item.js
+++ b/app/lib/utils/random-item.js
@@ -1,0 +1,19 @@
+/**
+ * Returns a random item from an array
+ * @param {Array} array - The array to select from
+ * @returns {*} A random item from the array, or null if array is empty/invalid
+ */
+function randomItem(array)
+{
+  // Handle invalid input
+  if (!Array.isArray(array) || array.length === 0)
+  {
+    return null
+  }
+
+  // Generate random index and return the item
+  const randomIndex = Math.floor(Math.random() * array.length)
+  return array[randomIndex]
+}
+
+module.exports.randomItem = randomItem

--- a/app/routes/find-record.js
+++ b/app/routes/find-record.js
@@ -1,5 +1,20 @@
 module.exports = router => {
 
+  router.get('/records', (req, res) => {
+
+    const data = req.session.data
+
+    const organisationVaccines = res.locals.currentOrganisation.vaccines || []
+
+    // Get a list of all the different vaccine names recorded so far
+    const vaccinesRecorded = [...new Set(data.vaccinationsRecorded
+      .map((record) => record.vaccine))]
+
+    res.render('records/index', {
+      vaccinesRecorded
+    })
+  })
+
  router.post('/records/answer-search', (req, res) => {
   const data = req.session.data
 

--- a/app/routes/helpers.js
+++ b/app/routes/helpers.js
@@ -111,7 +111,7 @@ module.exports = router => {
       })
     }
 
-    res.redirect('/home')
+    res.redirect('/records')
   });
 
 }

--- a/app/routes/helpers.js
+++ b/app/routes/helpers.js
@@ -1,3 +1,5 @@
+const { randomItem } = require('../lib/utils/random-item.js')
+
 module.exports = router => {
 
   router.get('/prototype-setup/setup-batches', (req, res) => {
@@ -67,6 +69,10 @@ module.exports = router => {
     const data = req.session.data
     const currentOrganisation = res.locals.currentOrganisation
 
+    const listOfFirstNames = ["Susana", "Steven", "Aleah", "Kaylen", "Stephan", "Donavon", "Emely", "Kailee", "Brooks", "Brenton", "Miles", "Emanuel", "Jedidiah", "Glenn", "Jude", "Ivory", "Austen", "Alyson", "Jaime", "Jordin", "Chad", "Janay", "Tahj", "Reginald", "Enoch", "Amiyah", "Benito", "April", "Joelle", "Brant"]
+
+    const listOfLastNames = ["Ross", "Friedman", "Switzer", "Devore", "Dominguez", "Kohn", "Moreau", "Farrar", "Hogue", "Goldsmith", "Wilkins", "Cornwell", "Wimberly", "Messer", "Woods", "Forrest", "Aiello", "Kuykendall", "Trout", "Bigelow", "Moreland", "Lentz", "Hurst", "Quinonez", "Pak", "McNally", "Longo", "Hunt", "Villa", "Breaux"]
+
     const vaccinationsToAdd = parseInt(data.numberOfVaccinationsToAdd);
 
     const dateToday = new Date()
@@ -76,10 +82,26 @@ module.exports = router => {
     const monthToday = (dateToday.getMonth() + 1)
     const yearToday = (dateToday.getFullYear())
 
+    const organisationVaccines = res.locals.currentOrganisation.vaccines || []
+
+    const vaccinesEnabled = organisationVaccines
+      .filter((vaccine) => vaccine.status === "enabled")
+
 
     for (let i = 0; i < vaccinationsToAdd; i++) {
 
       const generatedId = Math.floor(Math.random() * 10000000).toString()
+      const randomVaccine = randomItem(vaccinesEnabled)
+
+      const vaccineProductsInStock = data.vaccineStock.filter((vaccineStockItem) => vaccineStockItem.vaccine == randomVaccine.name)
+
+      const randomVaccineProduct = randomItem(vaccineProductsInStock)
+      const randombatchNumber = randomItem(randomVaccineProduct.batches)
+
+      const randomName = randomItem(listOfFirstNames) + " " + randomItem(listOfLastNames)
+
+      const randomNhsNumber = "9" + (100000000 + Math.floor(Math.random() * 900000000)).toString()
+
 
       data.vaccinationsRecorded.push({
         id: generatedId,
@@ -89,13 +111,13 @@ module.exports = router => {
           month: monthToday.toString(),
           year: yearToday.toString()
         },
-        vaccine: "RSV",
-        vaccineProduct: "Abrysvo",
+        vaccine: randomVaccine.name,
+        vaccineProduct: randomVaccineProduct.vaccineProduct,
         patient: {
-          name: "Jodie Brown",
-          nhsNumber: "9123123123"
+          name: randomName,
+          nhsNumber: randomNhsNumber
         },
-        batchNumber: "74725GJ0",
+        batchNumber: randombatchNumber.batchNumber,
         batchExpiryDate: "2025-01-05",
         vaccinator: "Anna Brown",
         eligibility: ["Pregnant"],

--- a/app/views/records/check.html
+++ b/app/views/records/check.html
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
   {{ backLink({
-    href: "/records/patient-history",
+    href: "/records",
     text: "Back"
   }) }}
 {% endblock %}

--- a/app/views/records/index.html
+++ b/app/views/records/index.html
@@ -8,48 +8,138 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-l">Records</h1>
-      <p class="nhsuk-body-l">Search for a vaccination record you want to view, edit or delete.</p>
+      <h1 class="nhsuk-heading-xl">Records</h1>
 
     </div>
   </div>
 
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-one-quarter">
+    <div class="nhsuk-grid-column-full">
 
       {% set filtersHtml %}
 
-        {% set vaccineItems = [] %}
-        {% for vaccine in (vaccinesRecorded | sort(false, false)) %}
-          {% set vaccineItems = (vaccineItems.push({
-            value: vaccine,
-            text: (vaccine | capitaliseFirstLetter)
-          }), vaccineItems) %}
-        {% endfor %}
+        <form action="/records" method="get" novalidate>
+
+          <div class="app-search">
+
+            <div class="app-search--input">
+              {{ input({
+                label: {
+                  text: "Patient name or NHS number"
+                }
+              }) }}
+            </div>
+
+            <div class="app-search--button">
+              {{ button({
+                classes: "nhsuk-u-margin-left-4",
+                text: "Search"
+              }) }}
+            </div>
+          </div>
+
+          {% set additionalFiltersHtml %}
+            {% set vaccineItems = [] %}
+            {% for vaccine in (vaccinesRecorded | sort(false, false)) %}
+              {% set vaccineItems = (vaccineItems.push({
+                value: vaccine,
+                text: (vaccine | capitaliseFirstLetter)
+              }), vaccineItems) %}
+            {% endfor %}
 
 
-        {{ checkboxes({
-          fieldset: {
-            legend: {
-              text: "Vaccine"
-            }
-          },
-          items: vaccineItems
-        }) }}
+            {{ checkboxes({
+              name: "vaccine",
+              classes: "app-checkboxes--small",
+              fieldset: {
+                legend: {
+                  text: "Vaccine",
+                  classes: "nhsuk-fieldset__legend--s nhsuk-u-margin-bottom-1"
+                }
+              },
+              items: vaccineItems
+            }) }}
+
+            {{ input({
+              name: "batchNumber",
+              classes: "nhsuk-input--width-20",
+              label: {
+                text: "Vaccine batch number",
+                classes: "nhsuk-label--s"
+              }
+            }) }}
+
+            {{ dateInput({
+              id: "dateOfBirth",
+              namePrefix: "dateOfBirth",
+              fieldset: {
+                legend: {
+                  text: "Patient date of birth",
+                  classes: "nhsuk-fieldset__legend--s nhsuk-u-margin-bottom-1"
+                }
+              },
+              errorMessage: {
+                text: dateOfBirthError
+              } if dateOfBirthError,
+              items: [
+                {
+                  name: "day",
+                  classes: "nhsuk-input--width-2 " + ("nhsuk-input--error" if dateOfBirthError else ""),
+                  value: data.dateOfBirth.day
+                },
+                {
+                  name: "month",
+                  classes: "nhsuk-input--width-2 " + ("nhsuk-input--error" if dateOfBirthError else ""),
+                  value: data.dateOfBirth.month
+                },
+                {
+                  name: "year",
+                  classes: "nhsuk-input--width-4 " + ("nhsuk-input--error" if dateOfBirthError else ""),
+                  value: data.dateOfBirth.year
+                }
+              ]
+            }) }}
+
+            {% set vaccinators = ["Anna Brown"] %}
+            {% set vaccinatorItems = [] %}
+
+            {% for vaccinator in (vaccinators | sort(false, false)) %}
+              {% set vaccinatorItems = (vaccinatorItems.push({
+                value: vaccinator,
+                text: vaccinator
+              }), vaccinatorItems) %}
+            {% endfor %}
+
+
+            {{ select({
+              label: {
+                text: "Vaccinator",
+                classes: "nhsuk-label--s"
+              },
+              items: vaccinatorItems
+            }) }}
+
+            {{ button({
+              text: "Update results",
+              classes: "nhsuk-button--secondary"
+            }) }}
+          {% endset %}
+
+          {{ details({
+            summaryText: "Additional filters",
+            html: additionalFiltersHtml
+          }) }}
+        </form>
       {% endset %}
 
 
       {{ card({
         classes: "nhsuk-u-margin-top-0 app-card--filters",
-        heading: "Filters",
+        heading: "Find a record",
         feature: true,
         descriptionHtml: filtersHtml
       }) }}
 
-
-    </div>
-
-    <div class="nhsuk-grid-column-three-quarters">
 
       <h2 class="nhsuk-heading-m">{{ data.vaccinationsRecorded | length | plural("record") }} </h2>
 
@@ -57,23 +147,24 @@
         <table class="nhsuk-table">
           <thead>
             <tr>
-              <th>Patient</th>
-              <th>Date</th>
-              <th>Vaccine</th>
-              <th>Vaccinator</th>
+              <th class="">Patient</th>
+              <th class="">Date</th>
+              <th class="nhsuk-u-width-one-third">Vaccine</th>
+              <th class="">Vaccinator</th>
             </tr>
           </thead>
           <tbody>
             {% for record in data.vaccinationsRecorded %}
               <tr>
                 <td>
-                  <a href="#">{{ record.patient.name }}</a><br>
+                  <a href="/records/records/{{ record.id }}">{{ record.patient.name }}</a><br>
                   <span class="nhsuk-u-secondary-text-colour nhsuk-u-nowrap">{{ record.patient.nhsNumber }}</span>
                 </td>
                 <td>
                   <span class="nhsuk-u-nowrap">
                     {{ record.date | isoDateFromDateInput | govukDate(truncate=true) }}
-                  </span>
+                  </span><br>
+                  <span class="nhsuk-u-secondary-text-colour nhsuk-u-nowrap">13:14</span>
                 </td>
                 <td>
                   {{ record.vaccine | capitaliseFirstLetter }}<br>
@@ -96,63 +187,7 @@
 
         <p>Showing 1 to {{ data.vaccinationsRecorded | length }} of {{ data.vaccinationsRecorded | length }} records<p>
 
-
-      <form action="/records/answer-search" method="post" novalidate>
-
-        {% set nhsNumberHtml %}
-
-          {{ input({
-            id: "nhsNumber",
-            name: "nhsNumber",
-            classes: "nhsuk-input--width-10",
-            inputmode: "numeric",
-
-            value: data.nhsNumber,
-            hint: {
-              text: "For example, 485 777 3456"
-            }
-          }) }}
-        {% endset %}
-
-
-        {{ radios({
-          idPrefix: "nhsNumberKnown",
-          name: "nhsNumberKnown",
-          fieldset: {
-            legend: {
-              html: "How do you want to search for a record?",
-              classes: "nhsuk-fieldset__legend--m",
-              isPageHeading: false
-            }
-          },
-          value: data.nhsNumberKnown,
-          items: [
-            {
-              value: "yes",
-              text: "NHS number",
-              conditional: {
-                html: nhsNumberHtml
-              }
-            },
-            {
-              value: "no",
-              text: "Patient details"
-            }
-          ]
-        }) }}
-
-        {{ button({
-          text: "Continue"
-        })}}
-      </form>
-
-
-
     </div>
   </div>
-
-
-
-
 
 {% endblock %}

--- a/app/views/records/index.html
+++ b/app/views/records/index.html
@@ -11,6 +11,92 @@
       <h1 class="nhsuk-heading-l">Records</h1>
       <p class="nhsuk-body-l">Search for a vaccination record you want to view, edit or delete.</p>
 
+    </div>
+  </div>
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-one-quarter">
+
+      {% set filtersHtml %}
+
+        {% set vaccineItems = [] %}
+        {% for vaccine in (vaccinesRecorded | sort(false, false)) %}
+          {% set vaccineItems = (vaccineItems.push({
+            value: vaccine,
+            text: (vaccine | capitaliseFirstLetter)
+          }), vaccineItems) %}
+        {% endfor %}
+
+
+        {{ checkboxes({
+          fieldset: {
+            legend: {
+              text: "Vaccine"
+            }
+          },
+          items: vaccineItems
+        }) }}
+      {% endset %}
+
+
+      {{ card({
+        classes: "nhsuk-u-margin-top-0 app-card--filters",
+        heading: "Filters",
+        feature: true,
+        descriptionHtml: filtersHtml
+      }) }}
+
+
+    </div>
+
+    <div class="nhsuk-grid-column-three-quarters">
+
+      <h2 class="nhsuk-heading-m">{{ data.vaccinationsRecorded | length | plural("record") }} </h2>
+
+      {% set resultsTableHtml %}
+        <table class="nhsuk-table">
+          <thead>
+            <tr>
+              <th>Patient</th>
+              <th>Date</th>
+              <th>Vaccine</th>
+              <th>Vaccinator</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for record in data.vaccinationsRecorded %}
+              <tr>
+                <td>
+                  <a href="#">{{ record.patient.name }}</a><br>
+                  <span class="nhsuk-u-secondary-text-colour nhsuk-u-nowrap">{{ record.patient.nhsNumber }}</span>
+                </td>
+                <td>
+                  <span class="nhsuk-u-nowrap">
+                    {{ record.date | isoDateFromDateInput | govukDate(truncate=true) }}
+                  </span>
+                </td>
+                <td>
+                  {{ record.vaccine | capitaliseFirstLetter }}<br>
+                  {{ record.vaccineProduct }}<br>
+                  <span class="nhsuk-u-secondary-text-colour">{{ record.batchNumber }}</span>
+                </td>
+                <td>{{ record.vaccinator }}</td>
+              </tr>
+
+
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endset %}
+
+      {{ card({
+        classes: "nhsuk-u-margin-top-0",
+        descriptionHtml: resultsTableHtml
+      }) }}
+
+        <p>Showing 1 to {{ data.vaccinationsRecorded | length }} of {{ data.vaccinationsRecorded | length }} records<p>
+
+
       <form action="/records/answer-search" method="post" novalidate>
 
         {% set nhsNumberHtml %}


### PR DESCRIPTION
This is a design spike to look at how we could update the 'Records' section so that, instead of just searching for records by patient name or NHS number, you can also filter by:

* vaccination type
* batch number
* vaccinator

We’ve heard these could be useful in some circumstances, such as correcting mistakes or checking that records were recorded correctly.

To accommodate these options, we could have a 'Filters' box, with the most common filters shown by default, and more available under a revealed section.

The records could be sorted by date and time recorded (most recent first), with pagination at the bottom.

By default, all vaccination records (from your organisation) would be shown (limited to most recent 500 or so?). This could mean that if you just need to correct a mistake recorded within the past few minutes or hour, you don't even need to use the filters at all, as it’ll be near the top of the list.

I did also consider having the filters in a left hand column, but the space is pretty tight given the number of filters and the number of columns shown in the list. However it could be possible to make it work if the content is reduced down a bit.

[Jira card](https://nhsd-jira.digital.nhs.uk/browse/RAVS-573)

## Screenshots

### Default filters

<img width="2240" height="1945" alt="localhost_3000_records" src="https://github.com/user-attachments/assets/d5c0c613-5284-4451-89cb-f26b03bb29d8" />

### Additional filters

<img width="2240" height="3515" alt="localhost_3000_records (1)" src="https://github.com/user-attachments/assets/49fa6e31-adb2-455a-9c11-8477eeaf986d" />

