### PR TITLE
Vax-history-options

### DIFF
--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -83,18 +83,16 @@
       {% endif %}
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
-      
-{% from "inset-text/macro.njk" import insetText %}
+
+      {% from "inset-text/macro.njk" import insetText %}
 
 {% set insetTextHtml %}
-  <p>This shows NHS vaccinations given in England. You should see:</p>
-  <ul>
-    <li>all COVID-19 and RSV records</li>
-    <li>flu records since September 2024</li>
-    <li>MMR records since September 2025</li>
-    <li>pneumococcal records since January 2026</li>
-    <li>pertussis records since September 2024 if recorded in RAVS</li>
-  </ul>
+        
+<p>This shows NHS vaccinations given in England.</p>
+
+<p>You should see all COVID-19, flu and RSV records going back to September 2024.</p>
+
+<p>It also includes some pertussis, pneumococcal and MMR records but less data is available for these.</p>
 {% endset %}
 
 {{ insetText({

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -84,6 +84,9 @@
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
       
+{% from "inset-text/macro.njk" import insetText %}
+
+{% set insetTextHtml %}
   <p>This shows NHS vaccinations given in England. You should see:</p>
   <ul>
     <li>all COVID-19 and RSV records</li>
@@ -92,8 +95,13 @@
     <li>pneumococcal records since January 2026</li>
     <li>pertussis records since September 2024 if recorded in RAVS</li>
   </ul>
+{% endset %}
 
+{{ insetText({
+  html: insetTextHtml
+}) }}
 
+      
     </div>
   </div>
   <div class="nhsuk-grid-row">

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -87,13 +87,16 @@
       {% from "details/macro.njk" import details %}
 
 {% call details({
-  summaryText: "Get your medical records",
+  summaryText: "Check which vaccinations are shown here",
   classes: "nhsuk-expander"
 }) %}
-  <p>You can see your GP records by:</p>
+  <p>This shows NHS vaccinations recorded in England. It includes:</p>
   <ul>
-    <li>asking for them at your GP surgery </li>
-    <li>going online to see them (if you have signed up for <a href="/using-the-nhs/nhs-services/gps/gp-online-services/">GP online services</a>) </li>
+    <li>all COVID-19 and RSV records </li>
+    <li>flu records since September 2024 </li>
+    <li>MMR records since September 2025 </li>
+    <li>pneumococcal records since January 2026 </li>
+    <li>pertussis records since September 2024, if recorded in RAVS </li>
   </ul>
 {% endcall %}
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -75,10 +75,187 @@
           </ul>
         {% endset %}
 
-
+        {{ details({
+          summaryText: "Screening considerations",
+          html: screeningConsiderations
+        }) }}
 
       {% endif %}
 
+      <h2 class="nhsuk-heading-m">Vaccination history</h2>
+
+      {% from "details/macro.njk" import details %}
+
+{% call details({
+  summaryText: "Which vaccinations are shown here?",
+  classes: "nhsuk-expander"
+}) %}
+  <p>You should see these NHS vaccinations given in England:</p>
+  <ul>
+    <li>all COVID-19 and RSV vaccinations</li>
+    <li>flu vaccinations recorded since 1 September 2024</li>
+    <li>MMR vaccinations recorded since 1 September 2025</li>
+    <li>pneumococcal vaccinations recorded since 1 January 2026</li>
+    <li>pertussis vaccinations recorded in RAVS since 1 September 2024</li>
+  </ul>
+{% endcall %}
+
+
+
+    </div>
+  </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+        {{ table({
+          panel: false,
+          caption: "",
+          firstCellIsHeader: false,
+          head: [
+            {
+              text: "Date"
+            },
+            {
+              text: "Vaccine"
+            },
+            {
+              text: "Product"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: "15 April 2025"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Spikevax JN.1"
+              }
+            ],[
+              {
+                text: "9 November 2024"
+              },
+              {
+                text: "MMR"
+              },
+              {
+                text: "Priorix"
+              }
+            ],[
+              {
+                text: "11 November 2024"
+              },
+              {
+                text: "RSV"
+              },
+              {
+                text: "Abrysvo"
+              }
+            ],
+            [
+              {
+                text: "29 October 2024"
+              },
+              {
+                text: "Pneumococcal"
+              },
+              {
+                text: "Pneumovax"
+              }
+            ],
+            [
+              {
+                text: "25 October 2024"
+              },
+              {
+                text: "Flu"
+              },
+              {
+                text: "Adjuvanted Quadrivalent Influenza Vaccine (aQIV)"
+              }
+            ],
+            [
+              {
+                text: "15 October 2023"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Comirnaty 30 Omicron XBB.1.5"
+              }
+            ],
+            [
+              {
+                text: "10 October 2023"
+              },
+              {
+                text: "Flu"
+              },
+              {
+                text: "Not known",
+                classes: "nhsuk-u-secondary-text-color"
+              }
+            ],
+            [
+              {
+                text: "7 October 2023"
+              },
+              {
+                text: "Pertussis"
+              },
+              {
+                text: "Boostrix-IPV suspension"
+              }
+            ],
+            [
+              {
+                text: "11 March 2022"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Moderna mRNA (Spikevax) Original"
+              }
+            ],
+            [
+              {
+                text: "4 December 2023"
+              },
+              {
+                text:
+      "MMR"
+              },
+              {
+                text: "Priorix"
+              }
+            ]
+          ]
+        }) }}
+
+        {{ pagination({
+          next: {
+            href: "#"
+          },
+          items: [
+            {
+              href: "#",
+              number: 1,
+              current: true
+            },
+            {
+              href: "#",
+              number: 2
+            },
+            {
+              href: "#",
+              number: 3
+            }
+          ]
+        }) }}
 
 
       <form action="{{ nextPage }}" method="post" novalidate>
@@ -91,4 +268,3 @@
   </div>
 
 {% endblock %}
-

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -84,20 +84,19 @@
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
 
-      {% from "inset-text/macro.njk" import insetText %}
+      {% from "details/macro.njk" import details %}
 
-{% set insetTextHtml %}
-        
-<p>This shows NHS vaccinations given in England.</p>
+{% call details({
+  summaryText: "Get your medical records",
+  classes: "nhsuk-expander"
+}) %}
+  <p>You can see your GP records by:</p>
+  <ul>
+    <li>asking for them at your GP surgery </li>
+    <li>going online to see them (if you have signed up for <a href="/using-the-nhs/nhs-services/gps/gp-online-services/">GP online services</a>) </li>
+  </ul>
+{% endcall %}
 
-<p>You should see all COVID-19, flu and RSV records going back to September 2024.</p>
-
-<p>It also includes some pertussis, pneumococcal and MMR records but less data is available for these.</p>
-{% endset %}
-
-{{ insetText({
-  html: insetTextHtml
-}) }}
 
       
     </div>

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -84,13 +84,13 @@
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
       
-  <p>This shows NHS vaccinations given in England. Currently you should see:</p>
+  <p>This shows NHS vaccinations given in England. You should see:</p>
   <ul>
-    <li>all COVID-19 and RSV vaccinations</li>
-    <li>flu vaccinations recorded since 1 September 2024</li>
-    <li>MMR vaccinations recorded since 1 September 2025</li>
-    <li>pneumococcal vaccinations recorded since 1 January 2026</li>
-    <li>pertussis vaccinations recorded in RAVS since 1 September 2024</li>
+    <li>all COVID-19 and RSV</li>
+    <li>flu rom 1 September 2024</li>
+    <li>MMR from 1 September 2025</li>
+    <li>pneumococcal from 1 January 2026</li>
+    <li>pertussis from 1 September 2024 if recorded in RAVS</li>
   </ul>
 
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -87,7 +87,7 @@
   <p>This shows NHS vaccinations given in England. You should see:</p>
   <ul>
     <li>all COVID-19 and RSV</li>
-    <li>flu rom 1 September 2024</li>
+    <li>flu from 1 September 2024</li>
     <li>MMR from 1 September 2025</li>
     <li>pneumococcal from 1 January 2026</li>
     <li>pertussis from 1 September 2024 if recorded in RAVS</li>

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -86,11 +86,11 @@
       
   <p>This shows NHS vaccinations given in England. You should see:</p>
   <ul>
-    <li>all COVID-19 and RSV</li>
-    <li>flu from 1 September 2024</li>
-    <li>MMR from 1 September 2025</li>
-    <li>pneumococcal from 1 January 2026</li>
-    <li>pertussis from 1 September 2024 if recorded in RAVS</li>
+    <li>all COVID-19 and RSV records</li>
+    <li>flu records since September 2024</li>
+    <li>MMR records since September 2025</li>
+    <li>pneumococcal records since January 2026</li>
+    <li>pertussis records since September 2024 if recorded in RAVS</li>
   </ul>
 
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -87,16 +87,16 @@
       {% from "details/macro.njk" import details %}
 
 {% call details({
-  summaryText: "Check which vaccinations are shown here",
+  summaryText: "This only shows some NHS vaccination records. See more details.",
   classes: "nhsuk-expander"
 }) %}
-  <p>This shows NHS vaccinations recorded in England. It includes:</p>
+  <p>Currently the history you see here includes:</p>
   <ul>
-    <li>all COVID-19 and RSV records </li>
+    <li>most COVID-19 and RSV records </li>
     <li>flu records since September 2024 </li>
+    <li>pertussis records since September 2024, if recorded in RAVS </li>
     <li>MMR records since September 2025 </li>
     <li>pneumococcal records since January 2026 </li>
-    <li>pertussis records since September 2024, if recorded in RAVS </li>
   </ul>
 {% endcall %}
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -83,14 +83,8 @@
       {% endif %}
 
       <h2 class="nhsuk-heading-m">Vaccination history</h2>
-
-      {% from "details/macro.njk" import details %}
-
-{% call details({
-  summaryText: "Which vaccinations are shown here?",
-  classes: "nhsuk-expander"
-}) %}
-  <p>You should see these NHS vaccinations given in England:</p>
+      
+  <p>This shows NHS vaccinations given in England. Currently you should see:</p>
   <ul>
     <li>all COVID-19 and RSV vaccinations</li>
     <li>flu vaccinations recorded since 1 September 2024</li>
@@ -98,8 +92,6 @@
     <li>pneumococcal vaccinations recorded since 1 January 2026</li>
     <li>pertussis vaccinations recorded in RAVS since 1 September 2024</li>
   </ul>
-{% endcall %}
-
 
 
     </div>


### PR DESCRIPTION
Trying out some different ways to tell users what's included in vaccination history. Currently we say:

**This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, MMR, and RSV, plus some pertussis and pneumococcal vaccination records.**

We could simply update this to:

A **This shows NHS vaccinations given in England. Currently it includes COVID-19, flu, and RSV, plus some MMR, pertussis and pneumococcal vaccination records.**

or 
B expand it to this:
This shows NHS vaccinations given in England.
You should see all COVID-19, flu, and RSV records since September 2024. 
Plus some pertussis, pneumococcal and MMR records but less data is available for these.
OR
This shows NHS vaccinations given in England.
You should see all COVID-19, flu, and RSV records since September 2024. 
It also includes pertussis vaccinations recorded in RAVS, and some pneumococcal and MMR records.
<img width="536" height="616" alt="image" src="https://github.com/user-attachments/assets/016ceee6-0d18-47e6-976f-99c24fd70e23" />

or 

C same as above but using inset component
<img width="548" height="647" alt="image" src="https://github.com/user-attachments/assets/6d39a110-bec9-4bfe-8a57-ec4cacbbf7ae" />

or 
D have a bulleted list with even more detail:
<img width="650" height="595" alt="image" src="https://github.com/user-attachments/assets/86211f68-34f7-4901-8420-210c5b9c7ce8" />

or
E have a bulleted list using inset text to make it stand out more:
<img width="520" height="637" alt="image" src="https://github.com/user-attachments/assets/bcba4750-fdf5-4fd8-ac96-40e3b922f9a5" />

or
F use the expander component
<img width="347" height="353" alt="image" src="https://github.com/user-attachments/assets/9780de93-613c-488e-ae6b-65018adc6b0a" />

<img width="350" height="419" alt="image" src="https://github.com/user-attachments/assets/a920442b-5e39-40fe-91a9-47d8155e3dfd" />



