### PR TITLE
Errors-PDS-and-history-API-issues

### DIFF
--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -56,10 +56,10 @@
           },
           {
             key: {
-              text: "NHS number"
+              text: "Postcode"
             },
             value: {
-              text: "9123456789"
+              text: "N7 0EA"
             }
           }
         ]

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -56,10 +56,10 @@
           },
           {
             key: {
-              text: "Postcode"
+              text: "NHS number"
             },
             value: {
-              text: "N7 0EA"
+              text: "9123456789"
             }
           }
         ]
@@ -69,7 +69,7 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "We do not have any vaccination history for this patient."
+  text: "We could not get any vaccination history for this patient."
 }) }}
 
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -25,7 +25,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Check Jodie Brown’s details and vaccination history</h1>
+      <h1 class="nhsuk-heading-l">Check Jodie Brown’s details</h1>
 
       {{ summaryList({
         classes: 'xnhsuk-summary-list--no-border',
@@ -56,7 +56,15 @@
           },
           {
             key: {
-              text: "Postcode"
+              text: "NHS number"
+            },
+            value: {
+              text: "9449306028"
+            }
+          },
+          {
+            key: {
+              text: "GP surgery"
             },
             value: {
               text: "N7 0EA"
@@ -69,7 +77,7 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "We can only show previous vaccinations that have been recorded in RAVS."
+  text: "We could not get any vaccination history for this patient."
 }) }}
       
       <h2 class="nhsuk-heading-m">Vaccination history</h2>

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -25,7 +25,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Check Jodie Brown’s details</h1>
+      <h1 class="nhsuk-heading-l">Check Jodie Brown’s details and vaccination history</h1>
 
       {{ summaryList({
         classes: 'xnhsuk-summary-list--no-border',

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -69,11 +69,49 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "We could not get any vaccination history for this patient."
+  text: "We can only show previous vaccinations that have been recorded in RAVS."
 }) }}
+      
+      <h2 class="nhsuk-heading-m">Vaccination history</h2>
 
+      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu and RSV, plus some pertussis, pneumococcal and MMR vaccination records.</p>
 
+    </div>
+  </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
 
+        {{ table({
+          panel: false,
+          caption: "",
+          firstCellIsHeader: false,
+          head: [
+            {
+              text: "Date"
+            },
+            {
+              text: "Vaccine"
+            },
+            {
+              text: "Product"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: "15 April 2025"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Comirnaty 3"
+              }
+            ]
+           ]
+        }) }}
+
+        
 
       <form action="{{ nextPage }}" method="post" novalidate>
         {{ button({

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -25,7 +25,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Check {{ data.patientName }}’s details</h1>
+      <h1 class="nhsuk-heading-l">Check Jodie Brown’s details</h1>
 
       {{ summaryList({
         classes: 'xnhsuk-summary-list--no-border',
@@ -56,28 +56,22 @@
           },
           {
             key: {
-              text: "NHS number"
+              text: "Postcode"
             },
             value: {
-              text: "9123456321"
+              text: "N7 0EA"
             }
           }
         ]
       }) }}
 
-      {% if data.vaccine == "COVID-19" %}
+      {% from "warning-callout/macro.njk" import warningCallout %}
 
-        {% set screeningConsiderations %}
-          <ul>
-            <li>Does the patient have a history of anaphylaxis or significant allergic reactions to any vaccines or their ingredients?</li>
-            <li>Has the patient had a serious adverse reaction after the COVID-19 vaccine?</li>
-            <li>Is the patient pregnant or could they be?</li>
-          </ul>
-        {% endset %}
+{{ warningCallout({
+  heading: "Important",
+  text: "We do not have any vaccination history for this patient."
+}) }}
 
-
-
-      {% endif %}
 
 
 

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -67,7 +67,7 @@
               text: "GP surgery"
             },
             value: {
-              text: "N7 0EA"
+              html: "Beech House surgery <br>1 Ash Tree Road<br>Knaresborough<br>HG5 0UB"
             }
           }
         ]

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -79,47 +79,7 @@
   heading: "Important",
   text: "We could not get any vaccination history for this patient."
 }) }}
-      
-      <h2 class="nhsuk-heading-m">Vaccination history</h2>
-
-      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu and RSV, plus some pertussis, pneumococcal and MMR vaccination records.</p>
-
-    </div>
-  </div>
-  <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-full">
-
-        {{ table({
-          panel: false,
-          caption: "",
-          firstCellIsHeader: false,
-          head: [
-            {
-              text: "Date"
-            },
-            {
-              text: "Vaccine"
-            },
-            {
-              text: "Product"
-            }
-          ],
-          rows: [
-            [
-              {
-                text: "15 April 2025"
-              },
-              {
-                text: "COVID-19"
-              },
-              {
-                text: "Comirnaty 3"
-              }
-            ]
-           ]
-        }) }}
-
-        
+          
 
       <form action="{{ nextPage }}" method="post" novalidate>
         {{ button({

--- a/app/views/record-vaccinations/patient-history-none.html
+++ b/app/views/record-vaccinations/patient-history-none.html
@@ -56,18 +56,10 @@
           },
           {
             key: {
-              text: "NHS number"
+              text: "Postcode"
             },
             value: {
-              text: "9449306028"
-            }
-          },
-          {
-            key: {
-              text: "GP surgery"
-            },
-            value: {
-              html: "Beech House surgery <br>1 Ash Tree Road<br>Knaresborough<br>HG5 0UB"
+              text: "N7 0EA"
             }
           }
         ]

--- a/app/views/record-vaccinations/patient-history-some.html
+++ b/app/views/record-vaccinations/patient-history-some.html
@@ -109,7 +109,7 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "For this patient, we can only show previous vaccinations that have been recorded in RAVS."
+  text: "There was a problem getting the patient's vaccination history. We could not access some vaccination records."
 }) }}
       
       <h2 class="nhsuk-heading-m">Vaccination history</h2>

--- a/app/views/record-vaccinations/patient-history-some.html
+++ b/app/views/record-vaccinations/patient-history-some.html
@@ -74,7 +74,7 @@
               text: "Postcode"
             },
             value: {
-              text: N7 0EA
+              text: "N7 0EA"
             }
           }
         ]

--- a/app/views/record-vaccinations/patient-history-some.html
+++ b/app/views/record-vaccinations/patient-history-some.html
@@ -101,7 +101,7 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "We can only show previous vaccination records that have been recorded in RAVS for this patient."
+  text: "We can only show previous vaccinations that were recorded in RAVS for this patient."
 }) }}
       
       <h2 class="nhsuk-heading-m">Vaccination history</h2>

--- a/app/views/record-vaccinations/patient-history-some.html
+++ b/app/views/record-vaccinations/patient-history-some.html
@@ -71,18 +71,10 @@
           },
           {
             key: {
-              text: "NHS number"
+              text: "Postcode"
             },
             value: {
-              text: data.nhsNumber
-            }
-          },
-          {
-            key: {
-              text: "GP surgery"
-            },
-            value: {
-              html: "Beech House surgery <br>1 Ash Tree Road<br>Knaresborough<br>HG5 0UB"
+              text: N7 0EA
             }
           }
         ]
@@ -109,7 +101,7 @@
 
 {{ warningCallout({
   heading: "Important",
-  text: "There was a problem getting the patient's vaccination history. We could not access some vaccination records."
+  text: "We can only show previous vaccination records that have been recorded in RAVS for this patient."
 }) }}
       
       <h2 class="nhsuk-heading-m">Vaccination history</h2>

--- a/app/views/record-vaccinations/patient-history-some.html
+++ b/app/views/record-vaccinations/patient-history-some.html
@@ -1,0 +1,165 @@
+
+{% extends 'layout.html' %}
+
+{% set pageName = "Check the patient's details" %}
+
+{% set currentSection = "vaccinate" %}
+
+
+{% set dateOfBirthHtml %}
+  {% if data.dateOfBirth.day %}
+    {{ (data.dateOfBirth | isoDateFromDateInput | govukDate) }}
+    <br>(76 years old)
+  {% else %}
+    {{ (data.dateOfBirth | govukDate) }}
+  {% endif %}
+{% endset %}
+
+{% if data.repeatVaccination === "yes" %}
+  {% set nextPage = "/record-vaccinations/consent" %}
+{% elseif data.repeatPatient === "yes" %}
+  {% set nextPage = "/record-vaccinations/vaccine" %}
+{% elseif data.vaccinationToday %}
+  {% set nextPage = "/record-vaccinations/vaccinator" %}
+{% else %}
+  {% set nextPage = "/record-vaccinations/vaccination-date" %}
+{% endif %}
+
+{% if data.repeatVaccination === "yes" %}
+  {% set previousPage = "/record-vaccinations/patient" %}
+{% elseif data.repeatPatient === "yes" %}
+  {% set previousPage = "/record-vaccinations/done" %}
+{% else %}
+  {% set previousPage = "/record-vaccinations" %}
+{% endif %}
+
+{% block beforeContent %}
+  {{ backLink({ href: previousPage }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-l">Check {{ data.firstName }} {{ data.lastName }}’s details and vaccination history</h1>
+
+      {{ summaryList({
+        rows: [
+          {
+            key: {
+              text: "Name"
+            },
+            value: {
+              text: (data.firstName + " " + data.lastName)
+            }
+          },
+          {
+            key: {
+              text: "Date of birth"
+            },
+            value: {
+              html: dateOfBirthHtml
+            }
+          },
+          {
+            key: {
+              text: "Address"
+            },
+            value: {
+              html: "73 Roman Rd<br>Leeds<br> LS2 5ZN"
+            }
+          },
+          {
+            key: {
+              text: "NHS number"
+            },
+            value: {
+              text: data.nhsNumber
+            }
+          },
+          {
+            key: {
+              text: "GP surgery"
+            },
+            value: {
+              html: "Beech House surgery <br>1 Ash Tree Road<br>Knaresborough<br>HG5 0UB"
+            }
+          }
+        ]
+      }) }}
+
+      {% if data.vaccine == "COVID-19" %}
+
+        {% set screeningConsiderations %}
+          <ul>
+            <li>Does the patient have a history of anaphylaxis or significant allergic reactions to any vaccines or their ingredients?</li>
+            <li>Has the patient had a serious adverse reaction after the COVID-19 vaccine?</li>
+            <li>Is the patient pregnant or could they be?</li>
+          </ul>
+        {% endset %}
+
+        {{ details({
+          summaryText: "Screening considerations",
+          html: screeningConsiderations
+        }) }}
+
+      {% endif %}
+
+      {% from "warning-callout/macro.njk" import warningCallout %}
+
+{{ warningCallout({
+  heading: "Important",
+  text: "For this patient, we can only show previous vaccinations that have been recorded in RAVS."
+}) }}
+      
+      <h2 class="nhsuk-heading-m">Vaccination history</h2>
+
+      <p>This shows NHS vaccinations given in England. Currently it includes COVID-19, flu and RSV, plus some pertussis, pneumococcal and MMR vaccination records.</p>
+
+    </div>
+  </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+        {{ table({
+          panel: false,
+          caption: "",
+          firstCellIsHeader: false,
+          head: [
+            {
+              text: "Date"
+            },
+            {
+              text: "Vaccine"
+            },
+            {
+              text: "Product"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: "15 April 2025"
+              },
+              {
+                text: "COVID-19"
+              },
+              {
+                text: "Comirnaty 3"
+              }
+            ]
+           ]
+        }) }}
+
+        
+
+      <form action="{{ nextPage }}" method="post" novalidate>
+        {{ button({
+          text: "Continue"
+        })}}
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR includes variations of the patient details and history page that we would show users in certain error scenarios. Full details of the related work are on https://nhsd-jira.digital.nhs.uk/browse/RAVS-2892

1. Limited patient details and no patient history
We  would show this if there is a problem with the PDS API and the user continues with no NHS number AND there is no history for this patient in the RAVS database. Note the patient details do not include NHS number or GP as the PDS lookup was not done.
<img width="392" height="398" alt="image" src="https://github.com/user-attachments/assets/2da7a7b6-30bd-47a7-a688-32f9aef92cc1" />
<br>
2. Limited patient details and some patient history
<br>
This would get shown if there is a problem with the PDS API so the user continues with no NHS number AND there is some history for this patient in the RAVS database. 
<img width="361" height="467" alt="image" src="https://github.com/user-attachments/assets/7f8ae813-a138-4304-9544-11e58975bd40" />
<br>
3. All patient details but no patient history
<br>
This would get shown if the PDS look up is successful but we cannot retrieve any history from the history APIs or database.
<img width="470" height="574" alt="image" src="https://github.com/user-attachments/assets/e8a4b44f-61f8-4dd6-8084-1861b5a9f1c2" />
<br>
4. All patient details but only some patient history
<br>
This would get shown if the PDS look up is successful but we can only retrieve partial history.
<img width="374" height="560" alt="image" src="https://github.com/user-attachments/assets/4ac7f862-0b55-43c9-a029-b697f0af3a21" />





