### PR TITLE
Change 3-in-1 to Td/IPV

### DIFF
--- a/app/data/organisations.js
+++ b/app/data/organisations.js
@@ -287,7 +287,7 @@ module.exports = [
       {name: "MenB", status: "enabled"},
       {name: "6-in-1", status: "enabled"},
       {name: "4-in-1 pre-school booster", status: "enabled"},
-      {name: "3-in-1 teenage booster", status: "enabled"},
+      {name: "Td/IPV", status: "enabled"},
       {name: "MenACWY", status: "enabled"},
       {name: "rotavirus", status: "enabled"},
       {name: "shingles", status: "enabled"}

--- a/app/data/vaccine-stock.js
+++ b/app/data/vaccine-stock.js
@@ -285,7 +285,7 @@ module.exports = [
   },
   {
     id: "RFF326464",
-    vaccine: "3-in-1 teenage booster",
+    vaccine: "Td/IPV",
     vaccineProduct: "Revaxis",
     organisationId: "RFF", // Barnsley Hospital NHS Foundation Trust
     siteId: "RFFPK", // Barnsley General Hospital

--- a/app/data/vaccines.js
+++ b/app/data/vaccines.js
@@ -232,7 +232,7 @@ module.exports = [
     ]
   },
   {
-    name: "3-in-1 teenage booster",
+    name: "Td/IPV",
     products: [
       {
         name: "Revaxis",

--- a/app/routes/record-vaccinations.js
+++ b/app/routes/record-vaccinations.js
@@ -863,7 +863,7 @@ module.exports = router => {
       redirectPath = "/record-vaccinations/add-batch"
     } else if (!vaccineBatch) {
       redirectPath = "/record-vaccinations/batch?showError=yes"
-    } else if (["COVID-19", "RSV", "3-in-1 teenage booster", "HPV", "MenACWY", "shingles"].includes(data.vaccine)) {
+    } else if (["COVID-19", "RSV", "Td/IPV", "HPV", "MenACWY", "shingles"].includes(data.vaccine)) {
       redirectPath = "/record-vaccinations/eligibility"
     } else if (data.vaccine === "pertussis") {
       redirectPath = "/record-vaccinations/patient-estimated-due-date"

--- a/app/views/record-vaccinations/eligibility.html
+++ b/app/views/record-vaccinations/eligibility.html
@@ -113,7 +113,7 @@
           {% set eligibilityOptions = RSVEligibilityOptions %}
         {% elif data.vaccine == "pneumococcal" %}
           {% set eligibilityOptions = pneumococcalEligibilityOptions %}
-        {% elif data.vaccine == "3-in-1 teenage booster" %}
+        {% elif data.vaccine == "Td/IPV" %}
           {% set eligibilityOptions = 3in1EligibilityOptions %}
         {% elif data.vaccine == "HPV" %}
           {% set eligibilityOptions = HPVEligibilityOptions %}


### PR DESCRIPTION
Updated mentions of **3-in-1 teenage booster** to **Td/IPV** to align with NHS.UK and Mavis. 

Full name on NHS.UK is **Td/IPV vaccine (3-in-1 teenage booster)** but generally it's shortened to **Td/IPV** and Mavis use **Td/IPV**.

Have amended the name in:
vaccines.js
vaccine-stock.js
organisations.js
eligibility.html
record-vaccinations.js