### PR TITLE
Updates to error pages

### DIFF
--- a/app/views/errors/no-patient-details.html
+++ b/app/views/errors/no-patient-details.html
@@ -13,8 +13,7 @@
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-      <p>Try again. Or if the problem persists and you urgently need to record a vaccination, <a href="https://guide.ravs.england.nhs.uk/service-unavailable/">download our paper form</a>.</p>
-
+      
 {% from "button/macro.njk" import button %}
 
 {{ button({

--- a/app/views/errors/no-vaccination-history.html
+++ b/app/views/errors/no-vaccination-history.html
@@ -15,10 +15,7 @@
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-
-  <p>You will not be able to see the patient's vaccination history.</p>
-
-
+  
 {% from "button/macro.njk" import button %}
 
 {{ button({

--- a/app/views/errors/still-no-patient-details.html
+++ b/app/views/errors/still-no-patient-details.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "There is a temporary problem getting Jodie Brown's vaccination history" %}
+{% set pageName = "There is still a problem getting the patient's details" %}
 
 
 {% block beforeContent %}
@@ -14,9 +14,6 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
-
-
-<p>You may not see all the vaccination records that are usually shown in this service.</p>
 
 {% from "button/macro.njk" import button %}
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -65,12 +65,12 @@
 
       <ul>
         <li><a href="/errors/500">Sorry, there is a problem with the service (500 error)</a></li>
-        <li><a href="/errors/503">Service unavailable (503 error)</a></li>
+        <li><a href="/errors/503">Sorry, the service is unavailable (503 error)</a></li>
         <li><a href="/errors/rate-limit">Rate limited (429 error)</a></li>
-        <li><a href="/auth/user-not-recognised">User not recognised (after a successful 3rd party login)</a></li>
-        <li><a href="/errors/no-patient-details">We cannot show patient details</a></li>
-        <li><a href="/errors/no-vaccination-history">We cannot show vaccination history</a></li>
-        <li><a href="/errors/partial-vaccination-history">We cannot show some vaccination history</a></li>
+        <li><a href="/auth/user-not-recognised">We cannot find a user with this email (after a successful 3rd party login)</a></li>
+        <li><a href="/errors/no-patient-details">There is a temporary problem getting the patient's details (PDS API issue)</a></li>
+        <li><a href="/errors/still-no-patient-details">There is still a problem getting the patient's details (ongoing PDS API issue)</a></li>
+        <li><a href="/errors/no-vaccination-history">There is a temporary problem getting [patient name]'s vaccination history (history API issue)</a></li>
       </ul>
 
       <h2>Messaging</h2>


### PR DESCRIPTION
Updated these error messages in line with agreed designs:

1. There is a temporary problem getting the patient's details
This only allows the user to try again or go back.
<img width="511" height="338" alt="image" src="https://github.com/user-attachments/assets/a1915ebf-2bf5-4417-89cb-35e4c856edf8" />

<br>

2. There is still a problem getting the patient's details
This allows the user to try again, go back, or continue anyway. Continue anyway would take them to the Continue with no NHS number page.
<img width="511" height="362" alt="image" src="https://github.com/user-attachments/assets/7beea621-62c8-42a4-ae0c-f84cc21a7d60" />

<br>

3. There is a temporary problem getting Jodie Brown's vaccination history
This is shown if no history at all can be displayed for the patient.
<img width="506" height="353" alt="image" src="https://github.com/user-attachments/assets/18d72cbc-a8c8-4b34-8775-77a2b5a4b5f7" />

<br>

And updated the links from the prototype index page.