### PR TITLE
Error page updates

### DIFF
--- a/app/views/auth/keycloak-existing-account-new-login.html
+++ b/app/views/auth/keycloak-existing-account-new-login.html
@@ -8,7 +8,7 @@
 
       <h1 class="nhsuk-heading-l">You previously logged in a different way</h1>
 
-      <p>Your email address <b>{{ data.email }}</b> is linked to a different log in option.</p>
+      <p>Your email address <b>james.blue@nhs.net</b> is linked to a different log in option.</p>
 
       <p>You need to log in with the option you used previously.</p>
 

--- a/app/views/auth/user-not-recognised.html
+++ b/app/views/auth/user-not-recognised.html
@@ -8,7 +8,7 @@
 
       <h1 class="nhsuk-heading-l">We cannot find a user with this email</h1>
 
-      <p>There is no Record a vaccination (RAVS) account for <b>{{ data.email }}</b>.</p>
+      <p>There is no Record a vaccination (RAVS) account for <b>james.blue@nhs.net</b>.</p>
 
       <p>If you’ve previously used RAVS, <a href="/auth/log-in">try logging in with the email address you used last time</a>.</p>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -68,6 +68,7 @@
         <li><a href="/errors/503">Sorry, the service is unavailable (503 error)</a></li>
         <li><a href="/errors/rate-limit">Rate limited (429 error)</a></li>
         <li><a href="/auth/user-not-recognised">We cannot find a user with this email (after a successful 3rd party login)</a></li>
+        <li><a href="/auth/keycloak-existing-account-new-login">You previously logged in a different way (Keycloak error)</a></li>
         <li><a href="/errors/no-patient-details">There is a temporary problem getting the patient's details (PDS API issue)</a></li>
         <li><a href="/errors/still-no-patient-details">There is still a problem getting the patient's details (ongoing PDS API issue)</a></li>
         <li><a href="/errors/no-vaccination-history">There is a temporary problem getting [patient name]'s vaccination history (history API issue)</a></li>


### PR DESCRIPTION
Hardcoded the email address in these 2 error pages:

- We cannot find a user with this email
- You previously logged in a different way

And added 'You previously logged in a different way' to the section on error pages on our prototype index.