### PR TITLE
Iterations to bulk onboarding after round 2 UR

### DIFF
--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -17,7 +17,7 @@
 
       <p>You can assign up to 10 lead administrators now, including you, to the pharmacies you selected. You will be able to assign further lead administrators later. </p>
 
-      <p>The people you add now must have an nhs.net email. But they can add more users later with various allowed emails. 
+      <p>The people you add now must have an nhs.net email. But users you add later at individual pharmacies can have a range of allowed emails. 
 
       {% call details({
   summaryText: "What can you do as a lead administrator?",

--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -15,9 +15,11 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-      <p>You can assign up to 10 lead administrators now, including you, to the {{ data.pharmacyIds | length }} pharmacies you selected.</p>
+      <p>You can assign up to 10 lead administrators now, including you, for the {{ data.pharmacyIds | length }} pharmacies you selected.</p>
+      
+      p>You will be able to add more users later at individual pharmacies, including more lead administrators.</p>>
 
-      <p>The people you add now must have an nhs.net email. But you can add more users later at individual pharmacies, including lead administrators, using a range of allowed emails.</p>
+      <p>The people you add now must have an nhs.net email. But when you add further users later, we allow a wide range of email addresses.</p>
 
       {% call details({
   summaryText: "What can you do as a lead administrator?",

--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -15,9 +15,9 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-      <p>You can assign up to 10 lead administrators now, including you, to the pharmacies you selected. You will be able to assign further lead administrators later. </p>
+      <p>You can assign up to 10 lead administrators now, including you, to the {{ data.pharmacyIds | length }} pharmacies you selected.</p>
 
-      <p>The people you add now must have an nhs.net email. But users you add later at individual pharmacies can have a range of allowed emails. 
+      <p>The people you add now must have an nhs.net email. But you can add more users later at individual pharmacies, including lead administrators, using a range of allowed emails.</p>
 
       {% call details({
   summaryText: "What can you do as a lead administrator?",

--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -17,7 +17,7 @@
 
       <p>You can assign up to 10 lead administrators now, including you, to the pharmacies you selected. You will be able to assign further lead administrators later. </p>
 
-      <p>The lead administrators you add now must have an nhs.net email. But they can add further users later who not need to have an nhs.net email. 
+      <p>The people you add now must have an nhs.net email. But they can add more users later with various allowed emails. 
 
       {% call details({
   summaryText: "What can you do as a lead administrator?",
@@ -31,7 +31,7 @@
     <li>create reports that include all {{ data.pharmacyIds | length }} pharmacies </li>
   </ul>
       
-<p>This table shows the permission levels you can give to users at individual pharmacies.</p>
+<p>This table shows the permission levels you can assign when you add users at individual pharmacies.</p>
 
 <table tabindex="0" class="nhsuk-table">
 <thead class="nhsuk-table__head">

--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -17,7 +17,7 @@
 
       <p>You can assign up to 10 lead administrators now, including you, for the {{ data.pharmacyIds | length }} pharmacies you selected.</p>
       
-      p>You will be able to add more users later at individual pharmacies, including more lead administrators.</p>>
+      <p>You will be able to add more users later at individual pharmacies, including more lead administrators.</p>
 
       <p>The people you add now must have an nhs.net email. But when you add further users later, we allow a wide range of email addresses.</p>
 

--- a/app/views/apply/contact-details-chain.html
+++ b/app/views/apply/contact-details-chain.html
@@ -15,20 +15,23 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-      <p>You can add up to 10 lead administrators now, including you.</p>
-      
-      <p>The lead administrators will:</p>
-      
-      <ul>
-        <li>get access to RAVS for all {{ data.pharmacyIds | length }} pharmacies</li>
-        <li>be able to create reports for all {{ data.pharmacyIds | length }} pharmacies</li>
-        <li>be able to add more users at each pharmacy and choose their permission level</li>
-      </ul>
+      <p>You can assign up to 10 lead administrators now, including you, to the pharmacies you selected. You will be able to assign further lead administrators later. </p>
+
+      <p>The lead administrators you add now must have an nhs.net email. But they can add further users later who not need to have an nhs.net email. 
 
       {% call details({
-        summaryText: "About our permission levels"
-      }) %}
-        <p>As a lead administrator, you can add more lead administrators, administrators or recorders.</p>
+  summaryText: "What can you do as a lead administrator?",
+  classes: "nhsuk-expander"
+}) %}
+  <p>A lead administrator added here can:</p>
+  <ul>
+    <li>access RAVS at all {{ data.pharmacyIds | length }} selected pharmacies </li>
+    <li>add users at each pharmacy, including more lead administrators, who can in turn add further users </li>
+    <li>assign different permission levels to the users they add </li>
+    <li>create reports that include all {{ data.pharmacyIds | length }} pharmacies </li>
+  </ul>
+      
+<p>This table shows the permission levels you can give to users at individual pharmacies.</p>
 
 <table tabindex="0" class="nhsuk-table">
 <thead class="nhsuk-table__head">
@@ -142,5 +145,6 @@
 
     </div>
   </div>
+
 
 {% endblock %}

--- a/app/views/apply/group-of-pharmacies.html
+++ b/app/views/apply/group-of-pharmacies.html
@@ -19,7 +19,7 @@
 
       <p>Before you start, we strongly recommend you read our <a href="#">guide to signing up for a group of pharmacies</a>.</p> 
 
-      <p>If you have any questions, <a href="#">email us</a> or <a href="#">join a drop-in session</a> .</p>
+      <p>If you have any questions, <a href="#">email us</a> or <a href="#">join a drop-in session</a>.</p>
 
     {{ button({
         text: "Continue",

--- a/app/views/apply/group-of-pharmacies.html
+++ b/app/views/apply/group-of-pharmacies.html
@@ -15,11 +15,9 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
     
-      <p>You can onboard all your pharmacies at once, or you can do it in batches.</p>
+      <p>You can onboard all your pharmacies at once, or you can do it in batches. The best option for you depends on your operating model.</p>
 
-      <p>Before you continue, we strongly recommend you read our <a href="#">guide to signing up a group of pharmacies.</a>.</p> 
-
-      <p>This explains how you add users, and how users can be associated with a group of pharmacies or a single pharmacy.
+      <p>Before you start, we strongly recommend you read our <a href="#">guide to signing up for a group of pharmacies</a>.</p> 
 
       <p>If you have any questions, <a href="#">email us</a> or <a href="#">join a drop-in session</a> .</p>
 

--- a/app/views/apply/group-of-pharmacies.html
+++ b/app/views/apply/group-of-pharmacies.html
@@ -21,7 +21,7 @@
 
       <p>This explains how you add users, and how users can be associated with a group of pharmacies or a single pharmacy.
 
-      <p>If you have any questions, <a href="#">email our onboarding team</a>.</p>
+      <p>If you have any questions, <a href="#">email us</a> or <a href="#">join a drop-in session</a> .</p>
 
     {{ button({
         text: "Continue",

--- a/app/views/apply/group-of-pharmacies.html
+++ b/app/views/apply/group-of-pharmacies.html
@@ -15,7 +15,7 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
     
-      <p>You can onboard all your pharmacies at once, or you can do it in batches. The best option for you depends on your operating model.</p>
+      <p>You can onboard all your pharmacies at once, or you can do it in batches. The best way to do this depends on your operating model.</p>
 
       <p>Before you start, we strongly recommend you read our <a href="#">guide to signing up for a group of pharmacies</a>.</p> 
 

--- a/app/views/apply/group-of-pharmacies.html
+++ b/app/views/apply/group-of-pharmacies.html
@@ -14,12 +14,14 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
+    
+      <p>You can onboard all your pharmacies at once, or you can do it in batches.</p>
 
-      <p>You can sign up all of your pharmacies at once, or you can do it in batches.</p>
+      <p>Before you continue, we strongly recommend you read our <a href="#">guide to signing up a group of pharmacies.</a>.</p> 
 
-      <p>For larger chains, we recommend signing up pharmacies based on how stores are managed in your organisation. <!-- See our <a href="#">guide to signing up a group of pharmacies</a>.--></p>
+      <p>This explains how you add users, and how users can be associated with a group of pharmacies or a single pharmacy.
 
-      <p>If you have any questions, <a href="#">join a drop-in session with our onboarding team</a>.</p>
+      <p>If you have any questions, <a href="#">email our onboarding team</a>.</p>
 
     {{ button({
         text: "Continue",

--- a/app/views/apply/pharmacies.html
+++ b/app/views/apply/pharmacies.html
@@ -22,7 +22,7 @@
         
       <p>There are {{ (pharmacies | length) + 7}} active pharmacies in your company according to the <a href="https://digital.nhs.uk/services/organisation-data-service">NHS Organisation Data Service</a> (ODS).</p>
 
-      <p>Pharmacies already using Record a vaccination (RAVS) are not listed below.</p>
+      <p>Pharmacies already signed up to the Record a vaccination service (RAVS) are not listed below.</p>
      
       {% call details({
       summaryText: "Your 7 pharmacies already signed up to RAVS"

--- a/app/views/apply/pharmacies.html
+++ b/app/views/apply/pharmacies.html
@@ -18,12 +18,26 @@
 
       <h1 class="nhsuk-heading-l">Select pharmacies</h1>
 
+      <p>You can sign up all your pharmacies at once by selecting all now. Or you can sign them up in batches, selecting a few now and then signing up another group later.
+        
       <p>There are {{ (pharmacies | length) + 7}} active pharmacies in your company according to the <a href="https://digital.nhs.uk/services/organisation-data-service">NHS Organisation Data Service</a> (ODS).</p>
 
-      <p>7 of them are already using RAVS and are not listed here.</p>
+      <p>Pharmacies already using Record a vaccination (RAVS) are not listed below.</p>
+     
+      {% call details({
+      summaryText: "7 pharmacies already using RAVS"
+      }) %}
+      <p>Asda Pharmacy, AB10 0JW (FDW48)</p>
+      <p>Asda Pharmacy, JD10 2JW (FXW46)</p>
+      <p>Asda Pharmacy, TN10 0JW (FQW48)</p>
+      <p>Asda Pharmacy, JD10 2JW (FZA46)</p>
+      <p>Asda Pharmacy, NW5 0JW (FBW48)</p>
+      <p>Asda Pharmacy, SE2 2JW (FNW46)</p>
+      <p>Asda Pharmacy, AB6 0JW (FMW48)</p>
+      {% endcall %}
 
       {% if (pharmacies | length) > 50 %}
-        <p>For larger chains, we recommend signing up pharmacies in batches based on how stores are managed in your organisation.</p>
+      
       {% endif %}
 
       {% set items = [] %}

--- a/app/views/apply/pharmacies.html
+++ b/app/views/apply/pharmacies.html
@@ -25,7 +25,7 @@
       <p>Pharmacies already using Record a vaccination (RAVS) are not listed below.</p>
      
       {% call details({
-      summaryText: "Your 7 pharmacies that are already using RAVS"
+      summaryText: "Your 7 pharmacies already signed up to RAVS"
       }) %}
       <p>Asda Pharmacy, AB10 0JW (FDW48)</p>
       <p>Asda Pharmacy, JD10 2JW (FXW46)</p>

--- a/app/views/apply/pharmacies.html
+++ b/app/views/apply/pharmacies.html
@@ -18,14 +18,14 @@
 
       <h1 class="nhsuk-heading-l">Select pharmacies</h1>
 
-      <p>You can sign up all your pharmacies at once by selecting all now. Or you can sign them up in batches, selecting a few now and then signing up another group later.
+      <p>You can sign up all your pharmacies at once or in batches.
         
       <p>There are {{ (pharmacies | length) + 7}} active pharmacies in your company according to the <a href="https://digital.nhs.uk/services/organisation-data-service">NHS Organisation Data Service</a> (ODS).</p>
 
       <p>Pharmacies already using Record a vaccination (RAVS) are not listed below.</p>
      
       {% call details({
-      summaryText: "7 pharmacies already using RAVS"
+      summaryText: "Your 7 pharmacies that are already using RAVS"
       }) %}
       <p>Asda Pharmacy, AB10 0JW (FDW48)</p>
       <p>Asda Pharmacy, JD10 2JW (FXW46)</p>

--- a/app/views/apply/pharmacies.html
+++ b/app/views/apply/pharmacies.html
@@ -21,11 +21,9 @@
       <p>You can sign up all your pharmacies at once or in batches.
         
       <p>There are {{ (pharmacies | length) + 7}} active pharmacies in your company according to the <a href="https://digital.nhs.uk/services/organisation-data-service">NHS Organisation Data Service</a> (ODS).</p>
-
-      <p>Pharmacies already signed up to the Record a vaccination service (RAVS) are not listed below.</p>
-     
+           
       {% call details({
-      summaryText: "Your 7 pharmacies already signed up to RAVS"
+      summaryText: "You have 7 pharmacies already signed up to RAVS."
       }) %}
       <p>Asda Pharmacy, AB10 0JW (FDW48)</p>
       <p>Asda Pharmacy, JD10 2JW (FXW46)</p>


### PR DESCRIPTION
Tweaked the following screens:

- Group pharmacy info screen - added link to the user guide and recommendation to read it, plus option to email us if you have questions.
<img width="508" height="380" alt="image" src="https://github.com/user-attachments/assets/15bec4f3-83ee-40f8-aa22-ab01d50044d4" />

<br>

- Select pharmacies screen - removed recommendation for chains to sign up in batches and added details of pharmacies already on RAVS. Not sure if using the details component would scale well if you have lots and lots of pharmacies - so we may need to think of a different way of showing the pharmacies that are already signed up.
<img width="344" height="411" alt="image" src="https://github.com/user-attachments/assets/ba40380e-25dc-4b80-8478-0786d938eef4" />


<br>

- Add lead admins screen - used expander instead of details and folded more info into it, added info about nhs.net email and when this applies, misc. content tweaks.
<img width="346" height="463" alt="image" src="https://github.com/user-attachments/assets/a046b7f1-96ec-40d6-8d3a-8bcf426fc467" />
