### PR TITLE
Updated reports to 90 days

### DIFF
--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -141,22 +141,26 @@
             },
             {
               "value": "Last7days",
-              "text": "Last 7 days"
+              "text": "Last 7 days (includes today)"
             },
             {
               "value": "Last14days",
-              "text": "Last 14 days"
+              "text": "Last 14 days (includes today)"
             },
             {
                 "value": "Last31days",
-                "text": "Last 31 days"
+                "text": "Last 31 days (includes today)"
+              },
+            {
+                "value": "Last90days",
+                "text": "Last 90 days (includes today)"
               },
             {
               divider: "or"
             },
             {
               "value": "custom_date_range",
-              "text": "Select custom date range up to 31 days",
+              "text": "Select custom date range up to 90 days",
               conditional: {
                 html: custom_date_range
               }


### PR DESCRIPTION
On the Choose a timeframe page in the reports section:

- added a radio for 'Last 90 days'
- added '(includes today)' after each radio mentioning days - to align with display in QA
- changed 31 to 90 on the last radio option

Old version:
<img width="447" height="430" alt="image" src="https://github.com/user-attachments/assets/a46f468f-fba0-4e5f-9710-510340c39782" />


New version:
<img width="461" height="446" alt="image" src="https://github.com/user-attachments/assets/b52a193b-88d9-4464-a75e-bb842e627937" />

