### PR TITLE
MenB updates

### DIFF
--- a/app/data/vaccines.js
+++ b/app/data/vaccines.js
@@ -198,6 +198,7 @@ module.exports = [
   },
   {
     name: "MenB",
+    availableToAllSites: true,
     products: [
       {
         name: "Bexsero",

--- a/app/views/record-vaccinations/dose.html
+++ b/app/views/record-vaccinations/dose.html
@@ -78,6 +78,10 @@
             {% set hintText = "Only given to some children in an at-risk group" %}
           {% endif %}
 
+          {% if data.vaccine == "MenB" and option == "Booster" %}
+            {% set hintText = "Usually only given as part of the routine infant schedule" %}
+          {% endif %}
+        
           {% if hintText %}
             {% set items = (items.push({
               text: option,

--- a/app/views/vaccines/choose-vaccine.html
+++ b/app/views/vaccines/choose-vaccine.html
@@ -88,9 +88,9 @@
 
           <form action="/vaccines/enable" method="post">
 
-          <p>You can now use Record a vaccination for national {{ vaccinesThatCanBeRequested | join(" and ") }} vaccinations.</p>
+          <p>You can use Record a vaccination for national COVID-19, flu and MenB vaccinations.</p>
 
-          <p>You'll be paid automatically for these vaccinations by the NHS Business Services Authority (NHSBSA), through Manage Your Service (MYS).</p>
+          <p>You'll be paid automatically for national COVID-19 and flu vaccinations by the NHS Business Services Authority (NHSBSA), through Manage Your Service (MYS).</p>
 
             {{ checkboxes({
               name: "vaccinesAdded",

--- a/app/views/vaccines/index.html
+++ b/app/views/vaccines/index.html
@@ -26,9 +26,8 @@
 
       {% set insetTextHtml %}
         <p>{{ tag({ text: "New", classes: "nhsuk-tag--blue"}) }}</p>
-        <p>You can now use Record a vaccination for national COVID-19 and flu vaccinations.</p>
+        <p>You can now use Record a vaccination for MenB vaccinations.</p>
 
-        <p>You'll be paid automatically for these vaccinations by the NHS Business Services Authority (NHSBSA), through Manage Your Service (MYS).</p>
       {% endset %}
 
       {{ insetText({


### PR DESCRIPTION
- Added this hint text below 'Booster' radio option on 'Which dose of the MenB vaccine is it?' page:
'Usually only given as part the routine infant schedule'
<img width="702" height="558" alt="image" src="https://github.com/user-attachments/assets/5fc313c4-a164-4b3e-bf9e-3a2e8a89a8a9" />


- Updated the details link on the Choose vaccine page. This only appears for pharmacies that have not enabled 1 or more of these 3 vaccines: COVID-19, flu and MenB. The updated text now includes mention of MenB.

<img width="1017" height="1039" alt="Screenshot 2026-05-14 at 13 47 27" src="https://github.com/user-attachments/assets/9583c641-21d1-475c-9734-a69ddc8e92c1" />


- Updated the details link that appears on the Vaccines page. This now only mentions Men B:
'You can now use Record a vaccination for MenB vaccinations.'

<img width="724" height="709" alt="image" src="https://github.com/user-attachments/assets/4da662ec-ac29-4aae-b644-0f856e4f1ffb" />
