### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,24 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    # Group packages into shared PRs
+    groups:
+      lint:
+        patterns:
+          - '@eslint/*'
+          - 'eslint'
+          - 'eslint-*'
+          - 'globals'
+          - 'prettier'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
           - 'prettier'
           - 'typescript-eslint'
           - '@typescript-eslint/*'
-


### PR DESCRIPTION
This should result in fewer PRs, as the 'lint' ones (which do things like check for typos and code style issues) will be grouped together.

Also changes schedule to weekly and adds a cooldown.