### PR TITLE
Update to hint text under booster option for MenB

### DIFF
--- a/app/views/record-vaccinations/dose.html
+++ b/app/views/record-vaccinations/dose.html
@@ -79,7 +79,7 @@
           {% endif %}
 
           {% if data.vaccine == "MenB" and option == "Booster" %}
-            {% set hintText = "Usually only given as part of the routine infant schedule" %}
+            {% set hintText = "Only given as part of the routine infant schedule" %}
           {% endif %}
         
           {% if hintText %}


### PR DESCRIPTION
After checking with clinical, changed the hint text under the Booster radio on the MenB dose question from:

Usually only given as part of the routine infant schedule
to:
Only given as part of the routine infant schedule

<img width="781" height="634" alt="image" src="https://github.com/user-attachments/assets/a1933449-d0b3-4894-9f5f-29a85bc1b96b" />


