### PR TITLE
Print view of todays appointments

### DIFF
--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -31,6 +31,8 @@
 // Add your custom CSS/Sass styles below...
 ///////////////////////////////////////////
 
+@import 'print';
+
 // Ensure hidden attribute works on button groups (which have display: flex)
 .nhsuk-button-group[hidden] {
   display: none;

--- a/app/assets/sass/print.scss
+++ b/app/assets/sass/print.scss
@@ -1,119 +1,252 @@
-/* Hide print-only content on screen */
-.app-print-only {
+/* Hidden on screen; shown in print */
+.app-print-masthead {
   display: none;
 }
 
+@page {
+  margin: 10mm;
+}
+
 @media print {
-  /* Show print-only content */
-  .app-print-only {
-    display: block !important;
+  .nhsuk-width-container {
+    max-width: none !important;
+    width: 100% !important;
+    margin: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
 
-  /* Hide navigation, tabs, and pagination */
+  .nhsuk-grid-row {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .nhsuk-grid-column-full,
+  .nhsuk-grid-column-two-thirds {
+    float: none !important;
+    width: 100% !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  html,
+  body,
+  .nhsuk-main-wrapper {
+    background: #fff !important;
+  }
+
   .nhsuk-header,
   .nhsuk-navigation,
   .nhsuk-breadcrumb,
   .nhsuk-phase-banner,
-  .nhsuk-pagination,
-  .nhsuk-tabs,
   .nhsuk-back-link,
-  .nhsuk-footer {
+  .nhsuk-pagination,
+  .app-appointments-imported-from,
+  .nhsuk-tabs__list,
+  .nhsuk-tabs__title {
     display: none !important;
   }
 
-  /* Hide imported-from MYA line on print */
-  .app-appointments-imported-from {
-    display: none !important;
+  .nhsuk-tabs,
+  .nhsuk-tabs__panel {
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
   }
 
-  /* Expand table to full width and add borders for clarity */
-  table.nhsuk-table,
+  .app-print-masthead {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 1px solid #b1b4b6;
+    padding-bottom: 12px;
+    margin: 0 0 20px 0;
+  }
+
+  .app-print-masthead__logo {
+    display: inline-flex;
+    color: #005eb8;
+    flex-shrink: 0;
+  }
+
+  .app-print-masthead__logo .nhsuk-header__logo {
+    width: 100px;
+    height: 40px;
+    display: block;
+  }
+
+  .app-print-masthead__service {
+    color: #0b0c0c;
+    font-weight: 400;
+    font-size: 20px;
+    line-height: 1.2;
+  }
+
+  .nhsuk-caption-m {
+    margin-bottom: 0 !important;
+  }
+
+  .nhsuk-heading-m {
+    margin-bottom: 40px !important;
+  }
+
   table.nhsuk-table-responsive {
     width: 100% !important;
-    border-collapse: collapse;
-    font-size: 14pt;
-  }
-  table.nhsuk-table th,
-  table.nhsuk-table td,
-  table.nhsuk-table-responsive th,
-  table.nhsuk-table-responsive td {
-    border: 1px solid #222;
-    padding: 8px;
+    border-collapse: collapse !important;
+    table-layout: fixed;
   }
 
-  /* Force desktop table layout in print instead of responsive stacked cells */
-  .nhsuk-table-responsive .nhsuk-table__head {
+  table.nhsuk-table-responsive thead {
     display: table-header-group !important;
-  }
-  .nhsuk-table-responsive .nhsuk-table__body {
-    display: table-row-group !important;
-  }
-  .nhsuk-table-responsive .nhsuk-table__row {
-    display: table-row !important;
-  }
-  .nhsuk-table-responsive .nhsuk-table__header,
-  .nhsuk-table-responsive .nhsuk-table__cell {
-    display: table-cell !important;
+    position: static !important;
     width: auto !important;
+    height: auto !important;
+    overflow: visible !important;
+    clip: auto !important;
+    clip-path: none !important;
+    white-space: normal !important;
   }
-  .nhsuk-table-responsive .nhsuk-table__cell::before {
+
+  table.nhsuk-table-responsive thead::before,
+  table.nhsuk-table-responsive thead::after {
     content: none !important;
     display: none !important;
   }
 
-  /* Keep secondary info stacked below primary value, as on desktop */
-  .nhsuk-table-responsive .nhsuk-table__cell .nhsuk-u-secondary-text-colour {
-    display: block !important;
+  table.nhsuk-table-responsive tbody {
+    display: table-row-group !important;
   }
 
-  /* Keep contact details column narrow and wrap content in print */
-  .nhsuk-table-responsive .nhsuk-table__header:nth-child(5),
-  .nhsuk-table-responsive .nhsuk-table__cell:nth-child(5) {
-    width: 10rem !important;
-    max-width: 10rem !important;
-    white-space: normal !important;
-    overflow-wrap: anywhere !important;
-    word-break: break-word !important;
+  table.nhsuk-table-responsive tr {
+    display: table-row !important;
   }
 
-  /* Remove actions column from printed table */
-  .nhsuk-table-responsive .nhsuk-table__header:nth-child(6),
-  .nhsuk-table-responsive .nhsuk-table__cell:nth-child(6) {
+  table.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row {
+    display: table-row !important;
+    margin-bottom: 0 !important;
+  }
+
+  table.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row th,
+  table.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
+    justify-content: normal !important;
+    text-align: left !important;
+    min-width: 0 !important;
+  }
+
+  table.nhsuk-table-responsive th,
+  table.nhsuk-table-responsive td {
+    display: table-cell !important;
+    vertical-align: top !important;
+    border-left: none !important;
+    border-right: none !important;
+    border-top: 1px solid #b1b4b6 !important;
+    border-bottom: 1px solid #b1b4b6 !important;
+    padding: 10px 16px 10px 0 !important;
+    color: #0b0c0c !important;
+  }
+
+  table.nhsuk-table-responsive th {
+    font-weight: 700 !important;
+    background-color: transparent !important;
+  }
+
+  table.nhsuk-table-responsive.nhsuk-table--with-sortable-columns thead th,
+  table.nhsuk-table-responsive thead th:first-child,
+  table.nhsuk-table-responsive tbody td:first-child {
+    padding-left: 0 !important;
+  }
+
+  table.nhsuk-table-responsive tbody tr:last-child td,
+  table.nhsuk-table-responsive tbody tr:last-child th {
+    border-bottom-width: 3px !important;
+  }
+
+  table.nhsuk-table-responsive td::before {
+    content: none !important;
     display: none !important;
   }
 
-  /* Add a little extra right padding for readability in print */
-  .nhsuk-table-responsive .nhsuk-table__header,
-  .nhsuk-table-responsive .nhsuk-table__cell,
-  table.nhsuk-table th,
-  table.nhsuk-table td,
-  table.nhsuk-table-responsive th,
-  table.nhsuk-table-responsive td {
-    padding-right: 12px !important;
-  }
-
-  /* Make headings stand out */
-  h1, h2, h3 {
-    color: #000 !important;
-    page-break-after: avoid;
-  }
-
-  /* Add extra spacing for readability */
-  .nhsuk-grid-row, .nhsuk-grid-column-full, .nhsuk-grid-column-two-thirds {
-    margin: 0;
-    padding: 0;
-  }
-
-  /* Show date and day at the top if present */
-  .nhsuk-heading-m, .nhsuk-caption-m {
+  table.nhsuk-table-responsive .nhsuk-u-secondary-text-colour {
     display: block !important;
-    color: #000 !important;
   }
 
-  /* Remove print-unfriendly backgrounds */
-  body, .nhsuk-main-wrapper {
-    background: #fff !important;
-    color: #000 !important;
+  /* Remove sorting affordances in print */
+  table.nhsuk-table-responsive th[aria-sort] {
+    pointer-events: none !important;
+    background-image: none !important;
+    text-decoration: none !important;
+    padding: 10px 16px 10px 0 !important;
+    color: #0b0c0c !important;
+    font-weight: 700 !important;
   }
 
+  table.nhsuk-table-responsive th[aria-sort]::before,
+  table.nhsuk-table-responsive th[aria-sort]::after {
+    content: none !important;
+    display: none !important;
+  }
+
+  table.nhsuk-table-responsive th[aria-sort="ascending"] button::after,
+  table.nhsuk-table-responsive th[aria-sort="descending"] button::after,
+  table.nhsuk-table-responsive th[aria-sort] button::before,
+  table.nhsuk-table-responsive th[aria-sort] button::after {
+    content: none !important;
+    display: none !important;
+    border: 0 !important;
+    background: transparent !important;
+    height: 0 !important;
+  }
+
+  table.nhsuk-table-responsive th[aria-sort] button,
+  table.nhsuk-table-responsive th[aria-sort] [role="button"] {
+    display: inline-block !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    color: inherit !important;
+    font: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-align: left !important;
+    background: transparent !important;
+    text-decoration: none !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-appearance: none !important;
+    appearance: none !important;
+  }
+
+  table.nhsuk-table-responsive th[aria-sort] button svg,
+  table.nhsuk-table-responsive th[aria-sort] [role="button"] svg,
+  table.nhsuk-table-responsive th[aria-sort] button .nhsuk-icon,
+  table.nhsuk-table-responsive th[aria-sort] [role="button"] .nhsuk-icon {
+    display: none !important;
+  }
+
+  table.app-appointments-scheduled-table {
+    table-layout: auto !important;
+    width: 100% !important;
+  }
+
+  table.app-appointments-scheduled-table .app-appointments-action-col,
+  table.app-appointments-scheduled-table th:last-child,
+  table.app-appointments-scheduled-table td:last-child,
+  table.app-appointments-scheduled-table a[href*="/record-vaccinations/patient-history"] {
+    display: none !important;
+    width: 0 !important;
+    max-width: 0 !important;
+    min-width: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    overflow: hidden !important;
+  }
+
+  table.nhsuk-table-responsive:not(.app-appointments-scheduled-table) th:nth-child(5),
+  table.nhsuk-table-responsive:not(.app-appointments-scheduled-table) td:nth-child(5) {
+    width: 10rem !important;
+    max-width: 10rem !important;
+    white-space: normal !important;
+    word-break: break-word !important;
+    overflow-wrap: anywhere !important;
+  }
 }

--- a/app/assets/sass/print.scss
+++ b/app/assets/sass/print.scss
@@ -1,0 +1,119 @@
+/* Hide print-only content on screen */
+.app-print-only {
+  display: none;
+}
+
+@media print {
+  /* Show print-only content */
+  .app-print-only {
+    display: block !important;
+  }
+
+  /* Hide navigation, tabs, and pagination */
+  .nhsuk-header,
+  .nhsuk-navigation,
+  .nhsuk-breadcrumb,
+  .nhsuk-phase-banner,
+  .nhsuk-pagination,
+  .nhsuk-tabs,
+  .nhsuk-back-link,
+  .nhsuk-footer {
+    display: none !important;
+  }
+
+  /* Hide imported-from MYA line on print */
+  .app-appointments-imported-from {
+    display: none !important;
+  }
+
+  /* Expand table to full width and add borders for clarity */
+  table.nhsuk-table,
+  table.nhsuk-table-responsive {
+    width: 100% !important;
+    border-collapse: collapse;
+    font-size: 14pt;
+  }
+  table.nhsuk-table th,
+  table.nhsuk-table td,
+  table.nhsuk-table-responsive th,
+  table.nhsuk-table-responsive td {
+    border: 1px solid #222;
+    padding: 8px;
+  }
+
+  /* Force desktop table layout in print instead of responsive stacked cells */
+  .nhsuk-table-responsive .nhsuk-table__head {
+    display: table-header-group !important;
+  }
+  .nhsuk-table-responsive .nhsuk-table__body {
+    display: table-row-group !important;
+  }
+  .nhsuk-table-responsive .nhsuk-table__row {
+    display: table-row !important;
+  }
+  .nhsuk-table-responsive .nhsuk-table__header,
+  .nhsuk-table-responsive .nhsuk-table__cell {
+    display: table-cell !important;
+    width: auto !important;
+  }
+  .nhsuk-table-responsive .nhsuk-table__cell::before {
+    content: none !important;
+    display: none !important;
+  }
+
+  /* Keep secondary info stacked below primary value, as on desktop */
+  .nhsuk-table-responsive .nhsuk-table__cell .nhsuk-u-secondary-text-colour {
+    display: block !important;
+  }
+
+  /* Keep contact details column narrow and wrap content in print */
+  .nhsuk-table-responsive .nhsuk-table__header:nth-child(5),
+  .nhsuk-table-responsive .nhsuk-table__cell:nth-child(5) {
+    width: 10rem !important;
+    max-width: 10rem !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+  }
+
+  /* Remove actions column from printed table */
+  .nhsuk-table-responsive .nhsuk-table__header:nth-child(6),
+  .nhsuk-table-responsive .nhsuk-table__cell:nth-child(6) {
+    display: none !important;
+  }
+
+  /* Add a little extra right padding for readability in print */
+  .nhsuk-table-responsive .nhsuk-table__header,
+  .nhsuk-table-responsive .nhsuk-table__cell,
+  table.nhsuk-table th,
+  table.nhsuk-table td,
+  table.nhsuk-table-responsive th,
+  table.nhsuk-table-responsive td {
+    padding-right: 12px !important;
+  }
+
+  /* Make headings stand out */
+  h1, h2, h3 {
+    color: #000 !important;
+    page-break-after: avoid;
+  }
+
+  /* Add extra spacing for readability */
+  .nhsuk-grid-row, .nhsuk-grid-column-full, .nhsuk-grid-column-two-thirds {
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Show date and day at the top if present */
+  .nhsuk-heading-m, .nhsuk-caption-m {
+    display: block !important;
+    color: #000 !important;
+  }
+
+  /* Remove print-unfriendly backgrounds */
+  body, .nhsuk-main-wrapper {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+}

--- a/app/views/appointments/_scheduled.html
+++ b/app/views/appointments/_scheduled.html
@@ -1,4 +1,4 @@
-<table class="nhsuk-table-responsive" role="table" data-module="nhsuk-table">
+<table class="nhsuk-table-responsive app-appointments-scheduled-table" role="table" data-module="nhsuk-table">
   <thead class="nhsuk-table__head" role="rowgroup">
     <tr>
       <th scope="col" class="nhsuk-table__header" aria-sort="ascending">Time</th>
@@ -8,7 +8,7 @@
       <th scope="col" class="nhsuk-table__header">Contact details</th>
 
       {% if currentDay == today %}
-        <th scope="col" class="nhsuk-table__header">Action</th>
+        <th scope="col" class="nhsuk-table__header app-appointments-action-col">Action</th>
       {% endif %}
 
     </tr>
@@ -39,7 +39,7 @@
         {% endif %}
       </td>
       {% if currentDay == today %}
-        <td class="nhsuk-table__cell">
+        <td class="nhsuk-table__cell app-appointments-action-col">
           <a href="/record-vaccinations/patient-history?nhsNumber={{ appointment.patient.nhsNumber }}&dateOfBirth={{ appointment.patient.dateOfBirth }}&firstName={{ appointment.patient.firstName }}&lastName={{ appointment.patient.lastName }}&from=appointments&appointmentId={{ appointment.id}}">Record<span class="nhsuk-u-visually-hidden"> vaccination for {{ appointment.patient.firstName }} {{ appointment.patient.lastName }}</span></a>
         </td>
       {% endif %}

--- a/app/views/appointments/index.html
+++ b/app/views/appointments/index.html
@@ -22,7 +22,7 @@
       
       
 
-      <p>Imported from <a href="https://mya-prototype-11c9c1433d21.herokuapp.com/" target="_blank" rel="noopener noreferrer">Manage your appointments (opens in new tab)</a></p>
+      <p class="app-appointments-imported-from">Imported from <a href="https://mya-prototype-11c9c1433d21.herokuapp.com/" target="_blank" rel="noopener noreferrer">Manage your appointments (opens in new tab)</a></p>
 
     </div>
   </div>
@@ -78,6 +78,10 @@
           }
         ]
       }) }}
+
+      <div class="app-print-only">
+        {% include "appointments/_scheduled.html" %}
+      </div>
 
 
     </div>

--- a/app/views/appointments/index.html
+++ b/app/views/appointments/index.html
@@ -13,6 +13,16 @@
 
 
 {% block content %}
+  <div class="app-print-masthead" role="presentation" aria-hidden="true">
+    <span class="app-print-masthead__logo">
+      <svg class="nhsuk-header__logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80" height="40" width="100" focusable="false" role="img" aria-label="NHS">
+        <title>NHS</title>
+        <path fill="currentcolor" d="M200 0v80H0V0h200Zm-27.5 5.5c-14.5 0-29 5-29 22 0 10.2 7.7 13.5 14.7 16.3l.7.3c5.4 2 10.1 3.9 10.1 8.4 0 6.5-8.5 7.5-14 7.5s-12.5-1.5-16-3.5L135 70c5.5 2 13.5 3.5 20 3.5 15.5 0 32-4.5 32-22.5 0-19.5-25.5-16.5-25.5-25.5 0-5.5 5.5-6.5 12.5-6.5a35 35 0 0 1 14.5 3l4-13.5c-4.5-2-12-3-20-3Zm-131 2h-22l-14 65H22l9-45h.5l13.5 45h21.5l14-65H64l-9 45h-.5l-13-45Zm63 0h-18l-13 65h17l6-28H117l-5.5 28H129l13.5-65H125L119.5 32h-20l5-24.5Z"/>
+      </svg>
+    </span>
+    <span class="app-print-masthead__service">Report a vaccination</span>
+  </div>
+
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
@@ -78,10 +88,6 @@
           }
         ]
       }) }}
-
-      <div class="app-print-only">
-        {% include "appointments/_scheduled.html" %}
-      </div>
 
 
     </div>


### PR DESCRIPTION
This is a print view of Today's appointments with unnecessary content removed using a css print stylesheet.

It removes:

- Navigation
- Next/Prev arrows
- Actions column
- "From MYA" text and link
- Tabs

It modifies:

- Table layout to use desktop layout rather than responsive layout
- Add some additional padding to table for legibility
