### PR TITLE
Add instruction to use NHS-allowed emails only

### DIFF
--- a/app/views/pharmacies/users/new.html
+++ b/app/views/pharmacies/users/new.html
@@ -14,6 +14,8 @@
 
       <h1 class="nhsuk-heading-l">Add user</h1>
 
+      <p class="nhsuk-body">Users must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank" class="nhsuk-link">list of approved email domains (opens in new tab)</a>.</p>
+
       <form action="/pharmacies/users/new-answer" method="post" novalidate="true">
 
         {{ input({


### PR DESCRIPTION
Added a note about NHS-approved email addresses with a link to the approved domains list.