### PR TITLE
Bugfix: missing joinWithAnd filter

### DIFF
--- a/app/views/appointments/_cancelled.html
+++ b/app/views/appointments/_cancelled.html
@@ -25,7 +25,7 @@
         <div class="nhsuk-u-secondary-text-colour">{{ appointment.patient.dateOfBirth | age }} old</div>
       </td>
       <td class="nhsuk-table__cell">
-        {{ appointment.vaccinations | joinWithAnd }}
+        {{ appointment.vaccinations | join(" and ") }}
       </td>
 
       <td class="nhsuk-table__cell nhsuk-u-text-break-word">

--- a/app/views/appointments/_completed.html
+++ b/app/views/appointments/_completed.html
@@ -24,7 +24,7 @@
         <div class="nhsuk-u-secondary-text-colour">{{ appointment.patient.dateOfBirth | age }} old</div>
       </td>
       <td class="nhsuk-table__cell">
-        {{ appointment.vaccinations | joinWithAnd }}
+        {{ appointment.vaccinations | join(" and ") }}
       </td>
       <td class="nhsuk-table__cell nhsuk-u-text-break-word">
         {% if appointment.patient.contactDetails.mobile %}

--- a/app/views/appointments/_scheduled.html
+++ b/app/views/appointments/_scheduled.html
@@ -28,7 +28,7 @@
         <div class="nhsuk-u-secondary-text-colour">{{ appointment.patient.dateOfBirth | age }} old</div>
       </td>
       <td class="nhsuk-table__cell">
-        {{ appointment.vaccinations | joinWithAnd }}
+        {{ appointment.vaccinations | join(" and ") }}
       </td>
       <td class="nhsuk-table__cell nhsuk-u-text-break-word">
         {% if appointment.patient.contactDetails.mobile %}


### PR DESCRIPTION
The `joinWithAnd` was used by this isn't defined anywhere.

Switching it to `join(" and ")` instead, so that those pages render.

This could be refactored into a `joinWithAnd` filter later if needed.