### PR TITLE
Updates to the Reports section

### DIFF
--- a/app/data/organisations.js
+++ b/app/data/organisations.js
@@ -1074,7 +1074,7 @@ module.exports = [
       },
       {
         id: "RW382",
-        name: "Ear nose and throad RMCH"
+        name: "Ear nose and throat RMCH"
       },
       {
         id: "RW391",

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -26,7 +26,7 @@ module.exports = {
   staffDataOptions: ["Recorder", "Vaccinator"],
   locationDataOptions: ["Site name", "Site ODS code", "Location type"],
   consentAndEligibilityDataOptions: ["Consent", "Eligibility", "Estimated due date"],
-  vaccinationDataOptions: ["Vaccine type", "Product", "Batch", "Batch expiry date", "Dose sequence", "Dose amount", "Vaccination site", "Vaccination date", "Comments"],
+  vaccinationDataOptions: ["Vaccine type", "Product", "Batch", "Batch expiry date", "Dose sequence", "Dose amount", "Vaccination route", "Vaccination date", "Comments"],
   paymentDataOptions: [
     {text: "Deposit ID", hint: "Set before we send the claim to NHSBSA"},
     {text: "Claim ID", hint: "Set when NHSBSA have received the claim"}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -22,7 +22,7 @@ module.exports = {
   vaccinationsRecorded: vaccinationsRecorded,
 
   // These are the options for extracting CSV reports
-  patientDataOptions: ["Name", "NHS number", "Gender", "Date of birth", "Address", "Postcode", "GP (ODS code only)"],
+  patientDataOptions: ["Name", "NHS number", "Gender", "Date of birth", "Address", "Postcode", "Contact details", "GP (ODS code only)"],
   staffDataOptions: ["Recorder", "Vaccinator"],
   locationDataOptions: ["Site name", "Site ODS code", "Location type"],
   consentAndEligibilityDataOptions: ["Consent", "Eligibility", "Estimated due date"],

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -22,7 +22,7 @@ module.exports = {
   vaccinationsRecorded: vaccinationsRecorded,
 
   // These are the options for extracting CSV reports
-  patientDataOptions: ["Name", "NHS number", "Gender", "Date of birth", "Address", "Postcode", "ODS code of their GP"],
+  patientDataOptions: ["Name", "NHS number", "Gender", "Date of birth", "Address", "Postcode", "GP (ODS code only)"],
   staffDataOptions: ["Recorder", "Vaccinator"],
   locationDataOptions: ["Site name", "Site ODS code", "Location type"],
   consentAndEligibilityDataOptions: ["Consent", "Eligibility", "Estimated due date"],

--- a/app/locals.js
+++ b/app/locals.js
@@ -15,6 +15,20 @@ module.exports = function(req, res, next) {
       'December'
     ]
 
+    const now = new Date()
+    const lastMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    res.locals.lastCalendarMonth = `${monthNames[lastMonthDate.getMonth()]} ${lastMonthDate.getFullYear()}`
+
+    const dayOfWeek = now.getDay() // 0 = Sunday, 1 = Monday
+    const daysSinceMonday = (dayOfWeek === 0 ? 7 : dayOfWeek) - 1
+    const lastMonday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysSinceMonday - 7)
+    const lastSunday = new Date(lastMonday.getFullYear(), lastMonday.getMonth(), lastMonday.getDate() + 6)
+    const formatWeekDay = (d) => {
+      const suffix = d.getDate() === lastSunday.getDate() && d.getMonth() === lastSunday.getMonth() ? ` ${monthNames[d.getMonth()]} ${d.getFullYear()}` : (d.getMonth() !== lastSunday.getMonth() ? ` ${monthNames[d.getMonth()]}` : '')
+      return `${d.getDate()}${suffix}`
+    }
+    res.locals.lastCalendarWeek = `${formatWeekDay(lastMonday)} to ${lastSunday.getDate()} ${monthNames[lastSunday.getMonth()]} ${lastSunday.getFullYear()}`
+
     const dashboardUpdatedAt = new Date(Date.now() - (30 * 60 * 1000))
     const hours24 = dashboardUpdatedAt.getHours()
     const hours12 = (hours24 % 12) || 12

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -211,6 +211,8 @@ module.exports = (router) => {
       .filter((organisation) => organisation.companyId === currentOrganisation.id)
     const allPharmaciesSelected = pharmacyIdsToReport.includes('all')
     const allVaccinesSelected = selectedVaccines.includes('all')
+    const canChangeSites = allSites.length > 1
+    const canChangePharmacies = allPharmacies.length > 1
 
     let sites, pharmacies
 
@@ -286,6 +288,8 @@ module.exports = (router) => {
       allSitesSelected,
       allPharmaciesSelected,
       allVaccinesSelected,
+      canChangeSites,
+      canChangePharmacies,
       from,
       to,
       vaccinesToReportDisplay

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -297,7 +297,7 @@ module.exports = (router) => {
     data.vaccinesToReport = null
 
 
-    res.redirect('/reports/download')
+    res.redirect('/reports/creating-report')
   })
 
 }

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -46,9 +46,15 @@ module.exports = (router) => {
   })
 
   router.post('/reports/choose-vaccines-answer', (req, res) => {
+    const data = req.session.data
+    const currentOrganisation = res.locals.currentOrganisation
+    const sites = currentOrganisation.sites || []
 
-    if (res.locals.currentOrganisation.type === "Pharmacy HQ") {
+    if (currentOrganisation.type === "Pharmacy HQ") {
       res.redirect('/reports/choose-pharmacies')
+    } else if (sites.length === 1) {
+      data.siteIdsToReport = [sites[0].id]
+      res.redirect('/reports/choose-data')
     } else {
       res.redirect('/reports/choose-site')
     }
@@ -106,9 +112,17 @@ module.exports = (router) => {
   })
 
   router.get('/reports/choose-site', (req, res) => {
+    const data = req.session.data
     const currentOrganisation = res.locals.currentOrganisation
 
     const sites = currentOrganisation.sites || []
+
+    if (sites.length === 1) {
+      data.siteIdsToReport = [sites[0].id]
+      res.redirect('/reports/choose-data')
+      return
+    }
+
     res.render('reports/choose-site', {
       sites
     })
@@ -186,6 +200,7 @@ module.exports = (router) => {
     const data = req.session.data
     const currentOrganisation = res.locals.currentOrganisation
     const siteIds = data.siteIdsToReport || []
+    const selectedVaccines = data.vaccinesToReport || []
     const today = new Date()
     const days = 86400000 // number of milliseconds in a day
 
@@ -203,6 +218,22 @@ module.exports = (router) => {
     const dateOption = data.date
 
     let from, to
+    let vaccinesToReportDisplay = selectedVaccines.filter((vaccineName) => vaccineName !== 'all')
+
+    if (selectedVaccines.includes('all')) {
+      const organisationVaccines = currentOrganisation.vaccines || []
+      let enabledVaccines = organisationVaccines.filter((vaccine) => vaccine.status === "enabled")
+
+      // Temporary: show all vaccines if none have batches added
+      if (enabledVaccines.length === 0) {
+        enabledVaccines = data.vaccines
+      }
+
+      vaccinesToReportDisplay = enabledVaccines.map((vaccine) => vaccine.name)
+    }
+
+    vaccinesToReportDisplay = [...new Set(vaccinesToReportDisplay)]
+      .sort((a, b) => a.localeCompare(b))
 
     switch (dateOption) {
       case 'custom_date_range':
@@ -229,6 +260,19 @@ module.exports = (router) => {
         from = new Date(today.getTime() - (31 * days)).toISOString().substring(0,10)
         to = today.toISOString().substring(0,10)
         break
+      case 'Last90days':
+        from = new Date(today.getTime() - (90 * days)).toISOString().substring(0,10)
+        to = today.toISOString().substring(0,10)
+        break
+      case 'LastCalendarMonth': {
+        const firstDayOfThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+        const firstDayOfLastMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+        const lastDayOfLastMonth = new Date(firstDayOfThisMonth.getTime() - days)
+
+        from = firstDayOfLastMonth.toISOString().substring(0,10)
+        to = lastDayOfLastMonth.toISOString().substring(0,10)
+        break
+      }
     }
 
 
@@ -237,7 +281,8 @@ module.exports = (router) => {
       sites,
       pharmacies,
       from,
-      to
+      to,
+      vaccinesToReportDisplay
     })
 
   })

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -184,7 +184,7 @@ module.exports = (router) => {
     } else {
 
       const error = {
-        text: "Select data for report",
+        text: "Select the data you want to include",
         href: "#data-1"
       }
 

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -205,13 +205,22 @@ module.exports = (router) => {
     const days = 86400000 // number of milliseconds in a day
 
     const pharmacyIdsToReport = data.pharmacyIdsToReport || []
+    const allSites = currentOrganisation.sites || []
+    const allSitesSelected = siteIds.includes('all')
+    const allPharmacies = data.organisations
+      .filter((organisation) => organisation.companyId === currentOrganisation.id)
+    const allPharmaciesSelected = pharmacyIdsToReport.includes('all')
+    const allVaccinesSelected = selectedVaccines.includes('all')
 
     let sites, pharmacies
 
-    sites = (currentOrganisation.sites || [])
-        .filter((site) => siteIds.includes(site.id))
+    sites = allSitesSelected
+      ? allSites
+      : allSites.filter((site) => siteIds.includes(site.id))
 
-    pharmacies = data.organisations.filter((pharmacy) => pharmacyIdsToReport.includes(pharmacy.id))
+    pharmacies = allPharmaciesSelected
+      ? allPharmacies
+      : allPharmacies.filter((pharmacy) => pharmacyIdsToReport.includes(pharmacy.id))
 
     const fromInput = data.from
     const toInput = data.to
@@ -220,7 +229,7 @@ module.exports = (router) => {
     let from, to
     let vaccinesToReportDisplay = selectedVaccines.filter((vaccineName) => vaccineName !== 'all')
 
-    if (selectedVaccines.includes('all')) {
+    if (allVaccinesSelected) {
       const organisationVaccines = currentOrganisation.vaccines || []
       let enabledVaccines = organisationVaccines.filter((vaccine) => vaccine.status === "enabled")
 
@@ -274,6 +283,9 @@ module.exports = (router) => {
     res.render('reports/check', {
       sites,
       pharmacies,
+      allSitesSelected,
+      allPharmaciesSelected,
+      allVaccinesSelected,
       from,
       to,
       vaccinesToReportDisplay

--- a/app/routes/reports.js
+++ b/app/routes/reports.js
@@ -248,22 +248,16 @@ module.exports = (router) => {
         from = new Date(today.getTime() - (1 * days)).toISOString().substring(0,10)
         to = new Date(today.getTime() - (1 * days)).toISOString().substring(0,10)
         break
-      case 'Last7days':
-        from = new Date(today.getTime() - (7 * days)).toISOString().substring(0,10)
-        to = today.toISOString().substring(0,10)
+      case 'LastCalendarWeek': {
+        const dayOfWeek = today.getDay() // 0 = Sunday, 1 = Monday, ...
+        const daysSinceMonday = (dayOfWeek === 0 ? 7 : dayOfWeek) - 1
+        const lastMonday = new Date(today.getFullYear(), today.getMonth(), today.getDate() - daysSinceMonday - 7)
+        const lastSunday = new Date(lastMonday.getTime() + (6 * days))
+
+        from = lastMonday.toISOString().substring(0,10)
+        to = lastSunday.toISOString().substring(0,10)
         break
-      case 'Last14days':
-        from = new Date(today.getTime() - (14 * days)).toISOString().substring(0,10)
-        to = today.toISOString().substring(0,10)
-        break
-      case 'Last31days':
-        from = new Date(today.getTime() - (31 * days)).toISOString().substring(0,10)
-        to = today.toISOString().substring(0,10)
-        break
-      case 'Last90days':
-        from = new Date(today.getTime() - (90 * days)).toISOString().substring(0,10)
-        to = today.toISOString().substring(0,10)
-        break
+      }
       case 'LastCalendarMonth': {
         const firstDayOfThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
         const firstDayOfLastMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1)

--- a/app/views/pharmacies/users/new.html
+++ b/app/views/pharmacies/users/new.html
@@ -13,6 +13,7 @@
     <div class="nhsuk-grid-column-three-quarters">
 
       <h1 class="nhsuk-heading-l">Add user</h1>
+      <p class="nhsuk-body">Users must have an NHS-approved email address. See the <a href="https://digital.nhs.uk/services/care-identity-service/applications-and-services/apply-for-care-id/care-identity-email-domain-allow-list" target="_blank" class="nhsuk-link">list of approved email domains (opens in new tab)</a>.</p
 
       <form action="/pharmacies/users/new-answer" method="post" novalidate="true">
 

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -23,8 +23,7 @@
       {% from "inset-text/macro.njk" import insetText %}
 
 {% set insetTextHtml %}
-  <p>You need to wait 3 minutes before you can start creating a report.</p>
-  <p>This is because another report is in progress for your organisation.</p>
+  <p>You need to wait 3 minutes before you can start creating a report. This is because another report is already in progress for your organisation.</p>
 {% endset %}
 
 {{ insetText({

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -23,7 +23,7 @@
       {% from "inset-text/macro.njk" import insetText %}
 
 {% set insetTextHtml %}
-  <p>You need to wait 3 minutes before you can start creating a report. This is because another report is already in progress for your organisation.</p>
+  <p>You need to wait before you can start creating a report. This is because another report is already in progress for your organisation.</p>
 {% endset %}
 
 {{ insetText({

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -1,0 +1,37 @@
+{% extends 'layout.html' %}
+
+{% set pageName = "Reports" %}
+
+{% set currentSection = "reports" %}
+
+{% block content %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% include "includes/notification.html" %}
+
+    </div>
+  </div>
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">Reports</h1>
+      <p>Create and download reports.</p>
+
+      {% if vaccinationsRecordedCount > 0 %}
+
+        {{ insetText({
+          html: "<p>You need to wait for 3 minutes before you can start creating a report. This is because another report is currently being created for your organisation.</p>"
+        })}}
+
+
+      {% else %}
+        <p>You have not yet recorded any vaccinations.</p>
+      {% endif %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -17,7 +17,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-l">Reports</h1>
+      <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">Reports</h1>
       <p>Create and download reports.</p>
 
       {% from "inset-text/macro.njk" import insetText %}

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -17,7 +17,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
 
-      <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">Reports</h1>
+      <h1 class="nhsuk-heading-l">Reports</h1>
       <p>Create and download reports.</p>
 
       {% from "inset-text/macro.njk" import insetText %}

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -23,7 +23,8 @@
       {% from "inset-text/macro.njk" import insetText %}
 
 {% set insetTextHtml %}
-  <p>You need to wait for 3 minutes before you can start creating a report. This is because another report is currently being created for your organisation.</p>
+  <p>You need to wait 3 minutes before you can start creating a report.</p>
+  <p>This is because another report is in progress for your organisation.</p>
 {% endset %}
 
 {{ insetText({

--- a/app/views/reports/alt-index.html
+++ b/app/views/reports/alt-index.html
@@ -20,16 +20,16 @@
       <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">Reports</h1>
       <p>Create and download reports.</p>
 
-      {% if vaccinationsRecordedCount > 0 %}
+      {% from "inset-text/macro.njk" import insetText %}
 
-        {{ insetText({
-          html: "<p>You need to wait for 3 minutes before you can start creating a report. This is because another report is currently being created for your organisation.</p>"
-        })}}
+{% set insetTextHtml %}
+  <p>You need to wait for 3 minutes before you can start creating a report. This is because another report is currently being created for your organisation.</p>
+{% endset %}
 
+{{ insetText({
+  html: insetTextHtml
+}) }}
 
-      {% else %}
-        <p>You have not yet recorded any vaccinations.</p>
-      {% endif %}
 
     </div>
   </div>

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -19,29 +19,43 @@
 
       <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
-      {% set dataFields = [] %}
-
-      {% for field in data.patientDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
-      {% for field in data.staffDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
-      {% for field in data.siteDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
-      {% for field in data.consentAndEligibilityDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
-      {% for field in data.vaccinationDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
-      {% for field in data.paymentDataToReport %}
-        {% set dataFields = (dataFields.push(field), dataFields) %}
-      {% endfor %}
+      {% set patientData = data.patientDataToReport or [] %}
+      {% set staffData = data.staffDataToReport or [] %}
+      {% set siteData = data.siteDataToReport or [] %}
+      {% set consentAndEligibilityData = data.consentAndEligibilityDataToReport or [] %}
+      {% set vaccinationData = data.vaccinationDataToReport or [] %}
+      {% set paymentData = data.paymentDataToReport or [] %}
 
       {% set dataValue %}
-        {{ dataFields | join(", ") }}
+        {% if (patientData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Patient data</h4>
+          <p class="nhsuk-u-margin-bottom-3">{{ patientData | join(", ") }}</p>
+        {% endif %}
+
+        {% if (staffData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Staff data</h4>
+          <p class="nhsuk-u-margin-bottom-3">{{ staffData | join(", ") }}</p>
+        {% endif %}
+
+        {% if (siteData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Site data</h4>
+          <p class="nhsuk-u-margin-bottom-3">{{ siteData | join(", ") }}</p>
+        {% endif %}
+
+        {% if (consentAndEligibilityData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Consent and eligibility data</h4>
+          <p class="nhsuk-u-margin-bottom-3">{{ consentAndEligibilityData | join(", ") }}</p>
+        {% endif %}
+
+        {% if (vaccinationData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Vaccination data</h4>
+          <p class="nhsuk-u-margin-bottom-3">{{ vaccinationData | join(", ") }}</p>
+        {% endif %}
+
+        {% if (paymentData | length) > 0 %}
+          <h4 class="nhsuk-heading-xs nhsuk-u-margin-bottom-1">Payment information</h4>
+          <p class="nhsuk-u-margin-bottom-0">{{ paymentData | join(", ") }}</p>
+        {% endif %}
       {% endset %}
 
       {% set sitesHtml %}
@@ -177,7 +191,7 @@
               text: "Data"
             },
             value: {
-              text: dataValue
+              html: dataValue
             },
             actions: {
               items: [

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -164,6 +164,7 @@
               html: sitesHtml
             },
             actions: {
+              classes: "nhsuk-u-visually-hidden" if not canChangeSites,
               items: [
               {
                 href: "/reports/choose-site",
@@ -181,6 +182,7 @@
               html: pharmaciesHtml
             },
             actions: {
+              classes: "nhsuk-u-visually-hidden" if not canChangePharmacies,
               items: [
                 {
                   href: "/reports/choose-pharmacies",

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -59,8 +59,10 @@
       {% endset %}
 
       {% set sitesHtml %}
-        {% if (sites | length) > 2 %}
-          {{ sites | length }} sites selected
+        {% if allSitesSelected %}
+          All {{ sites | length }} sites
+        {% elif (sites | length) > 10 %}
+          {{ sites | length }} sites
         {% else %}
           <ul class="nhsuk-list">
             {% for site in sites | sort(false, false, "name") %}
@@ -71,19 +73,31 @@
       {% endset %}
 
       {% set pharmaciesHtml %}
-        <ul class="nhsuk-list">
-          {% for pharmacy in pharmacies | sort(false, false, "name") %}
-            <li>{{ pharmacy.name }} ({{ pharmacy.id }})</li>
-          {% endfor %}
-        </ul>
+        {% if allPharmaciesSelected %}
+          All {{ pharmacies | length }} pharmacies
+        {% elif (pharmacies | length) > 10 %}
+          {{ pharmacies | length }} pharmacies
+        {% else %}
+          <ul class="nhsuk-list">
+            {% for pharmacy in pharmacies | sort(false, false, "name") %}
+              <li>{{ pharmacy.name }} ({{ pharmacy.id }})</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       {% endset %}
 
       {% set vaccinesToReportHtml %}
-        <ul class="nhsuk-list">
-          {% for vaccine in vaccinesToReportDisplay or [] %}
-            <li>{{ vaccine | capitaliseFirstLetter }}</li>
-          {% endfor %}
-        </ul>
+        {% if allVaccinesSelected %}
+          All {{ vaccinesToReportDisplay | length }} vaccines
+        {% elif (vaccinesToReportDisplay | length) > 10 %}
+          {{ vaccinesToReportDisplay | length }} vaccines
+        {% else %}
+          <ul class="nhsuk-list">
+            {% for vaccine in vaccinesToReportDisplay or [] %}
+              <li>{{ vaccine | capitaliseFirstLetter }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       {% endset %}
 
       {{ summaryList({
@@ -127,7 +141,7 @@
           },
           {
             key: {
-              text: ("Vaccines" if (vaccinesToReportDisplay | length) > 1 else "Vaccine")
+              text: ("Vaccines" if allVaccinesSelected or (vaccinesToReportDisplay | length) > 1 else "Vaccine")
             },
             value: {
               html: vaccinesToReportHtml
@@ -144,7 +158,7 @@
           },
           {
             key: {
-              text: ("Sites" if (data.siteIdsToReport | length) > 1 else "Site")
+              text: ("Sites" if allSitesSelected or (sites | length) > 1 else "Site")
             },
             value: {
               html: sitesHtml
@@ -161,7 +175,7 @@
           } if (sites | length) > 0,
           {
             key: {
-              text: ("Pharmacies" if (data.pharmacyIdsToReport | length) > 1 else "Pharmacy")
+              text: ("Pharmacies" if allPharmaciesSelected or (pharmacies | length) > 1 else "Pharmacy")
             },
             value: {
               html: pharmaciesHtml

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -59,11 +59,15 @@
       {% endset %}
 
       {% set sitesHtml %}
-        <ul class="nhsuk-list">
-          {% for site in sites | sort(false, false, "name") %}
-            <li>{{ site.name }} ({{ site.id }})</li>
-          {% endfor %}
-        </ul>
+        {% if (sites | length) > 2 %}
+          {{ sites | length }} sites selected
+        {% else %}
+          <ul class="nhsuk-list">
+            {% for site in sites | sort(false, false, "name") %}
+              <li>{{ site.name }} ({{ site.id }})</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       {% endset %}
 
       {% set pharmaciesHtml %}
@@ -74,10 +78,13 @@
         </ul>
       {% endset %}
 
-      {% set vaccinesToReportText = "" %}
-      {% if vaccinesToReportDisplay %}
-        {% set vaccinesToReportText = vaccinesToReportDisplay | join(", ") %}
-      {% endif %}
+      {% set vaccinesToReportHtml %}
+        <ul class="nhsuk-list">
+          {% for vaccine in vaccinesToReportDisplay or [] %}
+            <li>{{ vaccine | capitaliseFirstLetter }}</li>
+          {% endfor %}
+        </ul>
+      {% endset %}
 
       {{ summaryList({
         rows: [
@@ -123,7 +130,7 @@
               text: ("Vaccines" if (vaccinesToReportDisplay | length) > 1 else "Vaccine")
             },
             value: {
-              text: vaccinesToReportText
+              html: vaccinesToReportHtml
             },
             actions: {
               items: [

--- a/app/views/reports/check.html
+++ b/app/views/reports/check.html
@@ -61,11 +61,7 @@
       {% endset %}
 
       {% set vaccinesToReportText = "" %}
-      {% if data.vaccinesToReport %}
-        {% set vaccinesToReportDisplay = [] %}
-        {% for vaccine in (data.vaccinesToReport | sort(false, false, "name")) %}
-          {% set vaccinesToReportDisplay = (vaccinesToReportDisplay.push(vaccine ), vaccinesToReportDisplay) %}
-        {% endfor %}
+      {% if vaccinesToReportDisplay %}
         {% set vaccinesToReportText = vaccinesToReportDisplay | join(", ") %}
       {% endif %}
 
@@ -110,10 +106,10 @@
           },
           {
             key: {
-              text: ("Vaccines" if (data.vaccinesToReport | length) > 1 else "Vaccine")
+              text: ("Vaccines" if (vaccinesToReportDisplay | length) > 1 else "Vaccine")
             },
             value: {
-              text: vaccinesToReportText if data.vaccines
+              text: vaccinesToReportText
             },
             actions: {
               items: [

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -186,7 +186,7 @@
           } if error,
           fieldset: {
             legend: {
-              text: "Which details would you like to include?",
+              text: "Select how much data you want to include",
               isPageHeading: true,
               classes: "nhsuk-fieldset__legend--l"
             }
@@ -223,7 +223,7 @@
             },
             {
               value: "Vaccination",
-              text: "Vaccination",
+              text: "Vaccinations",
               conditional: {
                 html: vaccinationHtml
               }

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -186,7 +186,7 @@
           } if error,
           fieldset: {
             legend: {
-              text: "Select how much data you want to include",
+              text: "Select the details you want to include",
               isPageHeading: true,
               classes: "nhsuk-fieldset__legend--l"
             }

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Data details" %}
+{% set pageName = "Which details do you want to include?" %}
 
 {% set currentSection = "reports" %}
 
@@ -186,7 +186,7 @@
           } if error,
           fieldset: {
             legend: {
-              text: "Select the details you want to include",
+              text: "Which details do you want to include?",
               isPageHeading: true,
               classes: "nhsuk-fieldset__legend--l"
             }

--- a/app/views/reports/choose-data.html
+++ b/app/views/reports/choose-data.html
@@ -6,8 +6,16 @@
 
 
 {% block beforeContent %}
+  {% if currentOrganisation.type == "Pharmacy HQ" %}
+    {% set backLinkHref = "/reports/choose-pharmacies" %}
+  {% elif (currentOrganisation.sites | length) == 1 %}
+    {% set backLinkHref = "/reports/choose-vaccines" %}
+  {% else %}
+    {% set backLinkHref = "/reports/choose-site" %}
+  {% endif %}
+
   {{ backLink({
-    href: "/reports/choose-site",
+    href: backLinkHref,
     text: "Back"
   }) }}
 {% endblock %}

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -161,7 +161,7 @@
             },
             {
               "value": "custom_date_range",
-              "text": "Custom date range",
+              "text": "Custom date range up to 90 days",
               conditional: {
                 html: custom_date_range
               }

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "The timeframes relate to when a vaccination was given. However your report will show both the date the vaccination was given and the date it was recorded."
+            "text": "The timeframes relate to when a vaccination was given. However, your report will show both the date the vaccination was given and the date it was recorded."
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "Your report will show vaccinations given in the timeframe."
+            "text": "Your report will show vaccinations that were given during the timeframe you choose"
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -126,6 +126,9 @@
               "isPageHeading": true
             }
           },
+          "hint": {
+            "text": "Timeframes are based on the date a vaccination was administered."
+          },
           value: data.date,
           errorMessage: {
             text: dateError
@@ -140,27 +143,25 @@
               "text": "Yesterday"
             },
             {
-              "value": "Last7days",
-              "text": "Last 7 days (includes today)"
+              "value": "LastCalendarWeek",
+              "text": "Last calendar week",
+              "hint": {
+                "text": lastCalendarWeek
+              }
             },
             {
-                "value": "Last31days",
-                "text": "Last 31 days (includes today)"
-              },
-            {
-                "value": "Last90days",
-                "text": "Last 90 days (includes today)"
-              },
-            {
-                "value": "LastCalendarMonth",
-                "text": "Last calendar month"
+              "value": "LastCalendarMonth",
+              "text": "Last calendar month",
+              "hint": {
+                "text": lastCalendarMonth
+              }
             },
             {
               divider: "or"
             },
             {
               "value": "custom_date_range",
-              "text": "Select custom date range up to 90 days",
+              "text": "Custom date range",
               conditional: {
                 html: custom_date_range
               }

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -144,10 +144,6 @@
               "text": "Last 7 days (includes today)"
             },
             {
-              "value": "Last14days",
-              "text": "Last 14 days (includes today)"
-            },
-            {
                 "value": "Last31days",
                 "text": "Last 31 days (includes today)"
               },
@@ -155,6 +151,10 @@
                 "value": "Last90days",
                 "text": "Last 90 days (includes today)"
               },
+            {
+                "value": "LastCalendarMonth",
+                "text": "Last calendar month"
+            },
             {
               divider: "or"
             },

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "Timeframes are based on the date a vaccination was administered."
+            "text": "The timeframes relate to when a vaccination was given. However your report will show both the date the vaccination was given and the date it was recorded."
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "Your report will show vaccinations that were given during the timeframe you choose"
+            "text": "Your report will show vaccinations given during this timeframe"
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "Your report will show vaccinations that were given in your chosen timeframe."
+            "text": "Your report will show vaccinations given in the timeframe."
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "The timeframes relate to when a vaccination was given. However, your report will show both the date the vaccination was given and the date it was recorded."
+            "text": "Your report will show vaccinations that were given in your chosen timeframe."
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-dates.html
+++ b/app/views/reports/choose-dates.html
@@ -127,7 +127,7 @@
             }
           },
           "hint": {
-            "text": "Your report will show vaccinations given during this timeframe"
+            "text": "Your report will include vaccinations given during this timeframe"
           },
           value: data.date,
           errorMessage: {

--- a/app/views/reports/choose-pharmacies.html
+++ b/app/views/reports/choose-pharmacies.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Select the pharmacies you want to include" %}
+{% set pageName = "Which pharmacies do you want to include?" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-pharmacies.html
+++ b/app/views/reports/choose-pharmacies.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Choose pharmacies" %}
+{% set pageName = "Select the pharmacies you want to include" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-site.html
+++ b/app/views/reports/choose-site.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Choose sites" %}
+{% set pageName = "Which sites do you want to include?" %}
 
 {% set currentSection = "reports" %}
 

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Choose vaccines" %}
+{% set pageName = "Select the vaccines you want to include" %}
 
 {% set currentSection = "reports" %}
 
@@ -46,7 +46,7 @@
           name: "vaccinesToReport",
           fieldset: {
             legend: {
-              text: "Choose vaccines",
+              text: "Select the vaccines you want to include",
               size: "l",
               isPageHeading: true
             }

--- a/app/views/reports/choose-vaccines.html
+++ b/app/views/reports/choose-vaccines.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Select the vaccines you want to include" %}
+{% set pageName = "Which vaccines you want to include?" %}
 
 {% set currentSection = "reports" %}
 
@@ -46,7 +46,7 @@
           name: "vaccinesToReport",
           fieldset: {
             legend: {
-              text: "Select the vaccines you want to include",
+              text: "Which vaccines do you want to include?",
               size: "l",
               isPageHeading: true
             }

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -11,7 +11,9 @@
 
 <h1 class="nhsuk-heading-m">We are creating your report</h1>
 
-<p>This can take up to a few minutes. You can navigate away from this page but do not close this tab or window.</p> 
+<p>This can take up to a few minutes.</p> 
+      
+<p>You can navigate away from this page but do not close this tab or window.</p> 
 
 
 {% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -1,19 +1,20 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Creating report" %}
+{% set pageName = "We are creating your report" %}
+
+{% set currentSection = "reports" %}
 
 
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
+      <h1 class="nhsuk-heading-l">We are creating your report</h1>
+
+      <p>This can take up to a few minutes.</p> 
       
-
-<h1 class="nhsuk-heading-m">We are creating your report</h1>
-
-<p>This can take up to a few minutes.</p> 
-      
-<p>You can navigate away from this page but do not close this tab or window.</p> 
+      <p>You can navigate away from this page but do not close this tab or window.</p>
 
 
-{% endblock %}
+    </div>
+  </div>

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -18,3 +18,4 @@
 
     </div>
   </div>
+{% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -1,0 +1,60 @@
+{% extends 'layout.html' %}
+
+{% set pageName = "Add a list of NHS numbers" %}
+
+{% set currentSection = "lists" %}
+
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% if (errors | length) > 0 %}
+        {{ errorSummary({
+          titleText: "There is a problem",
+          errorList: errors
+        }) }}
+      {% endif %}
+
+      <form action="/lists/add-numbers" method="post" novalidate>
+
+<h1 class="nhsuk-heading-m">We are creating your report</h1>
+
+<p>This can take up to 2 minutes.</p>
+
+
+<div class="loader"></div>
+<style>
+.loader {
+    border: 12px solid #DEE0E2;
+    border-radius: 50%;
+    border-top-color: #005eb8;
+    width: 80px;
+    height: 80px;
+    -webkit-animation: spin 2s linear infinite;
+    animation: spin 2s linear infinite;
+  }
+  @-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(360deg); }
+  }
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+  .center {
+  margin: auto;
+
+}
+</style>
+
+<br>
+
+
+<p>Looking up NHS numbers <br> Found 16 out of 104</p>
+
+
+<meta http-equiv=refresh content="5; url=http:/lists/list">
+
+
+{% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -11,7 +11,7 @@
 
 <h1 class="nhsuk-heading-m">We are creating your report</h1>
 
-<p>This can take up to a few minutes.</p> 
+<p>This can take up to a few minutes. You can navigate away from this page but do not close this tab or window.</p> 
 
 
 {% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -39,7 +39,7 @@
 }
 </style>
 
-<meta http-equiv=refresh content="5; url=http:/lists/list">
+<meta http-equiv=refresh content="5; url=http:/reports/download">
 
 
 {% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -11,36 +11,7 @@
 
 <h1 class="nhsuk-heading-m">We are creating your report</h1>
 
-<p>This can take a few minutes.</p>
-
-
-<div class="loader"></div>
-<style>
-.loader {
-    border: 12px solid #DEE0E2;
-    border-radius: 50%;
-    border-top-color: #005eb8;
-    width: 80px;
-    height: 80px;
-    -webkit-animation: spin 2s linear infinite;
-    animation: spin 2s linear infinite;
-  }
-  @-webkit-keyframes spin {
-    0% { -webkit-transform: rotate(0deg); }
-    100% { -webkit-transform: rotate(360deg); }
-  }
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-  .center {
-  margin: auto;
-
-}
-</style>
-
-<meta http-equiv=refresh content="5; url=http:"/reports/download">
-    
+<p>This can take up to a few minutes.</p> 
 
 
 {% endblock %}

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -15,6 +15,10 @@
       
       <p>You can navigate away from this page but do not close this tab or window.</p>
 
+      <p class="nhsuk-u-font-size-14 nhsuk-u-secondary-text-colour">
+        Prototype only: <a href="/reports/download">Simulate report complete</a>
+      </p>
+
 
     </div>
   </div>

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -1,26 +1,17 @@
 {% extends 'layout.html' %}
 
-{% set pageName = "Add a list of NHS numbers" %}
-
-{% set currentSection = "lists" %}
+{% set pageName = "Creating report" %}
 
 
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {% if (errors | length) > 0 %}
-        {{ errorSummary({
-          titleText: "There is a problem",
-          errorList: errors
-        }) }}
-      {% endif %}
-
-      <form action="/lists/add-numbers" method="post" novalidate>
+      
 
 <h1 class="nhsuk-heading-m">We are creating your report</h1>
 
-<p>This can take up to 2 minutes.</p>
+<p>This can take a few minutes.</p>
 
 
 <div class="loader"></div>
@@ -47,12 +38,6 @@
 
 }
 </style>
-
-<br>
-
-
-<p>Looking up NHS numbers <br> Found 16 out of 104</p>
-
 
 <meta http-equiv=refresh content="5; url=http:/lists/list">
 

--- a/app/views/reports/creating-report.html
+++ b/app/views/reports/creating-report.html
@@ -39,7 +39,8 @@
 }
 </style>
 
-<meta http-equiv=refresh content="5; url=http:/reports/download">
+<meta http-equiv=refresh content="5; url=http:"/reports/download">
+    
 
 
 {% endblock %}

--- a/app/views/reports/download.html
+++ b/app/views/reports/download.html
@@ -11,8 +11,6 @@
 
       <h1 class="nhsuk-heading-l">Your report is ready</h1>
 
-      <p>You can now download your report.</p>
-
       {{ button({
         "text": "Download report",
         "href": "/reports"

--- a/app/views/reports/download.html
+++ b/app/views/reports/download.html
@@ -11,7 +11,7 @@
 
       <h1 class="nhsuk-heading-l">Your report is ready</h1>
 
-      <p>You have created a report from 16 July to 30 July 2024 for COVID-19 and flu at Verrington (RH635)</p>
+      <p>You can now download your report.</p>
 
       {{ button({
         "text": "Download report",

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -31,6 +31,10 @@
           "href": "/reports/choose-dates"
         }) }}
 
+        <p class="nhsuk-u-font-size-14 nhsuk-u-secondary-text-colour">
+          Prototype only: <a href="/reports/alt-index">Simulate when someone else is creating a report</a>
+        </p>
+
       {% else %}
         <p>You have not yet recorded any vaccinations.</p>
       {% endif %}

--- a/app/views/reports/index.html
+++ b/app/views/reports/index.html
@@ -23,7 +23,7 @@
       {% if vaccinationsRecordedCount > 0 %}
 
         {{ insetText({
-          html: "<p>Reports may take longer to process if you choose more data or a wider date range.</p>"
+          html: "<p>Reports may take longer to create if you include more data or a wider timeframe.</p>"
         })}}
 
         {{ button({


### PR DESCRIPTION
Added 2 new pages to the Reports section:

1. creating-report - this would be shown to users if a report cannot be generated instantly. It would appear after **Check and confirm** and before **Your report is ready**

<img width="788" height="496" alt="image" src="https://github.com/user-attachments/assets/58d97cfa-8cbe-4f80-acec-9faebf327525" />

Also tried this version but decided with Caitlin that the spinner is not ideal if it may take minutes rather than seconds. 

<img width="665" height="407" alt="image" src="https://github.com/user-attachments/assets/1098404d-4bee-47f9-bdd1-adf5eb8b1d8f" />

2. alt-index - a different version of the landing page of the Reports sections, for any user who comes to this page while another report for their organisation is in progress. 

Question for devs: does this screen refresh automatically when the user can start creating a report, or do they need to click on something again? If latter, do we need a 'Try again' button?

<img width="784" height="523" alt="image" src="https://github.com/user-attachments/assets/6fa4c726-d33d-4799-8d98-eada8017db05" />

