### PR TITLE
Update link text for opening in a new tab

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -33,7 +33,7 @@
         New features
       </strong>
       <span class="govuk-phase-banner__text">
-        We regularly update the service. Find out more in <a class="govuk-link" href="https://guide.ravs.england.nhs.uk/whats-new/" target="_blank" rel="noreferrer noopener">What's new (opens in a new tab)</a>
+        We regularly update the service. Find out more in <a class="govuk-link" href="https://guide.ravs.england.nhs.uk/whats-new/" target="_blank" rel="noreferrer noopener">What's new (opens in new tab)</a>
       </span>
     </p>
   </div>


### PR DESCRIPTION
Made a tiny change to link text from 'opens in a new tab' to 'opens in new tab' for consistency with other similar links.